### PR TITLE
Adding Type object to Component object to avoid extra Type.GetType call

### DIFF
--- a/Structurizr.Core/Analysis/TypeBasedComponentFinderStrategy.cs
+++ b/Structurizr.Core/Analysis/TypeBasedComponentFinderStrategy.cs
@@ -52,9 +52,10 @@ namespace Structurizr.Analysis
         {
             foreach (Component component in ComponentFinder.Container.Components)
             {
-                if (component.Type != null)
+                if (!string.IsNullOrEmpty(component.Type))
                 {
-                    Type type = Type.GetType(component.Type);
+                    Type type = component.TypeObject ?? Type.GetType(component.Type);
+
                     foreach (PropertyInfo propertyInfo in type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
                     {
                         string propertyType = propertyInfo.PropertyType.AssemblyQualifiedName;

--- a/Structurizr.Core/Model/Component.cs
+++ b/Structurizr.Core/Model/Component.cs
@@ -41,6 +41,8 @@ namespace Structurizr
         [DataMember(Name="code", EmitDefaultValue=false)]
         public HashSet<CodeElement> Code { get; internal set; }
 
+        public Type TypeObject { get; set; }
+
         internal Component()
         {
             Code = new HashSet<CodeElement>();

--- a/Structurizr.Core/Model/Container.cs
+++ b/Structurizr.Core/Model/Container.cs
@@ -55,17 +55,17 @@ namespace Structurizr
 
         public Component AddComponent(string name, string description, string technology)
         {
-            return this.AddComponent(name, "", description, technology);
+            return this.AddComponent(name, string.Empty, description, technology, null);
         }
 
         public Component AddComponent(string name, Type type, string description, string technology)
         {
-            return AddComponent(name, type.AssemblyQualifiedName, description, technology);
+            return AddComponent(name, type.AssemblyQualifiedName, description, technology, type);
         }
 
-        public Component AddComponent(string name, string type, string description, string technology)
+        public Component AddComponent(string name, string type, string description, string technology, Type typeObj)
         {
-            Component component = Model.AddComponent(this, name, type, description, technology);
+            Component component = Model.AddComponent(this, name, type, description, technology, typeObj);
 
             return component;
         }

--- a/Structurizr.Core/Model/Model.cs
+++ b/Structurizr.Core/Model/Model.cs
@@ -148,16 +148,17 @@ namespace Structurizr
 
         internal Component AddComponent(Container parent, string name, string description, string technology)
         {
-            return this.AddComponent(parent, name, null, description, technology);
+            return this.AddComponent(parent, name, null, description, technology, null);
         }
 
-        internal Component AddComponent(Container parent, string name, string type, string description, string technology)
+        internal Component AddComponent(Container parent, string name, string type, string description, string technology, Type typeObj)
         {
             Component component = new Component();
             component.Name = name;
             component.Type = type;
             component.Description = description;
             component.Technology = technology;
+            component.TypeObject = typeObj;
 
             component.Parent = parent;
             parent.Add(component);


### PR DESCRIPTION
This fixes an issue that I have found where assemblies are force loaded (using, say, Assembly.LoadFrom) and GetType can fail sometimes...also perhaps a bit more efficient since it avoids the extra GetType call.