### PR TITLE
Made constructors and Add* Methods public in order to enable subclassing Model classes

### DIFF
--- a/Structurizr.Core/Model/Component.cs
+++ b/Structurizr.Core/Model/Component.cs
@@ -41,7 +41,7 @@ namespace Structurizr
         [DataMember(Name="code", EmitDefaultValue=false)]
         public HashSet<CodeElement> Code { get; internal set; }
 
-        internal Component()
+        public Component()
         {
             Code = new HashSet<CodeElement>();
         }
@@ -85,7 +85,7 @@ namespace Structurizr
             }
         }
 
-        internal void AddSupportingType(CodeElement codeElement)
+        public void AddSupportingType(CodeElement codeElement)
         {
             Code.Add(codeElement);
         }

--- a/Structurizr.Core/Model/Container.cs
+++ b/Structurizr.Core/Model/Container.cs
@@ -43,7 +43,7 @@ namespace Structurizr
             }
         }
 
-        internal Container()
+        public Container()
         {
             this.Components = new HashSet<Component>();
         }
@@ -70,7 +70,7 @@ namespace Structurizr
             return component;
         }
 
-        internal void Add(Component component)
+        public void Add(Component component)
         {
             if (GetComponentWithName(component.Name) == null)
             {

--- a/Structurizr.Core/Model/Model.cs
+++ b/Structurizr.Core/Model/Model.cs
@@ -70,16 +70,28 @@ namespace Structurizr
                 softwareSystem.Name = name;
                 softwareSystem.Description = description;
 
-                SoftwareSystems.Add(softwareSystem);
-
-                softwareSystem.Id = idGenerator.GenerateId(softwareSystem);
-                AddElementToInternalStructures(softwareSystem);
+                Add(softwareSystem);
 
                 return softwareSystem;
             }
             else
             {
                 return null;
+            }
+        }
+
+        /// <summary>
+        /// Adds a software system to the model
+        /// (unless one exists with the same name already).
+        /// </summary>
+        /// <param name="softwareSystem">The SoftwareSystem instance to be added to the model</param>
+        public void Add(SoftwareSystem softwareSystem)
+        {
+            if (GetSoftwareSystemWithName(softwareSystem.Name) == null)
+            {
+                SoftwareSystems.Add(softwareSystem);
+                softwareSystem.Id = idGenerator.GenerateId(softwareSystem);
+                AddElementToInternalStructures(softwareSystem);
             }
         }
 
@@ -133,6 +145,17 @@ namespace Structurizr
                 container.Description = description;
                 container.Technology = technology;
 
+                return this.AddContainer(parent, container);
+            }
+            else {
+                return null;
+            }
+        }
+
+        internal Container AddContainer(SoftwareSystem parent, Container container)
+        {
+            if (parent.GetContainerWithName(container.Name) == null)
+            {
                 container.Parent = parent;
                 parent.Add(container);
 
@@ -141,7 +164,8 @@ namespace Structurizr
 
                 return container;
             }
-            else {
+            else
+            {
                 return null;
             }
         }

--- a/Structurizr.Core/Model/Person.cs
+++ b/Structurizr.Core/Model/Person.cs
@@ -39,7 +39,7 @@ namespace Structurizr
             }
         }
 
-        internal Person()
+        public Person()
         {
         }
 

--- a/Structurizr.Core/Model/SoftwareSystem.cs
+++ b/Structurizr.Core/Model/SoftwareSystem.cs
@@ -46,7 +46,7 @@ namespace Structurizr
             }
         }
 
-        internal SoftwareSystem()
+        public SoftwareSystem()
         {
             this.Containers = new HashSet<Container>();
         }
@@ -103,6 +103,16 @@ namespace Structurizr
         public Container AddContainer(String name, String description, String technology)
         {
             return Model.AddContainer(this, name, description, technology);
+        }
+
+        /// <summary>
+        /// Adds a container
+        /// (unless one exists with the same name already).
+        /// </summary>
+        /// <param name="container">the container to be added</param>
+        public Container AddContainer(Container container)
+        {
+            return Model.AddContainer(this, container);
         }
 
         internal void Add(Container container)

--- a/Structurizr.CoreTests/Model/ComponentTests.cs
+++ b/Structurizr.CoreTests/Model/ComponentTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Structurizr.CoreTests.MyApp;
 
 namespace Structurizr.CoreTests
 {
@@ -69,5 +70,14 @@ namespace Structurizr.CoreTests
             Assert.IsTrue(component.Tags.Contains(Tags.Component));
         }
 
+        [TestMethod]
+        public void Test_Adding_A_CodeElement_Adds_It_To_The_List_Of_Elements()
+        {
+            Component component = new Component();
+            MyClass myClass = new MyClass();
+            component.AddSupportingType(myClass);
+
+            Assert.IsTrue(component.Code.Contains(myClass));
+        }
     }
 }

--- a/Structurizr.CoreTests/Model/ContainerTests.cs
+++ b/Structurizr.CoreTests/Model/ContainerTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Structurizr.CoreTests.MyApp;
 
 namespace Structurizr.CoreTests
 {
@@ -55,6 +56,27 @@ namespace Structurizr.CoreTests
 
             Assert.IsTrue(container.Tags.Contains(Tags.Element));
             Assert.IsTrue(container.Tags.Contains(Tags.Container));
+        }
+
+        [TestMethod]
+        public void Test_Adding_A_Component_Adds_It_To_The_List_Of_Components()
+        {
+            MyComponent myComponent = new MyComponent();
+            container.Add(myComponent);
+
+            Assert.IsTrue(container.Components.Contains(myComponent));
+        }
+
+        [TestMethod]
+        public void Test_Adding_A_Component__Does_Not_Add_It_To_The_List_Of_Components_If_A_Component_With_The_Same_Name_Exists()
+        {
+            MyComponent myComponent = new MyComponent();
+            MyComponent myComponent2 = new MyComponent();
+
+            container.Add(myComponent);
+            container.Add(myComponent2);
+
+            Assert.IsFalse(container.Components.Contains(myComponent2));
         }
 
     }

--- a/Structurizr.CoreTests/Model/MyApp/MyClass.cs
+++ b/Structurizr.CoreTests/Model/MyApp/MyClass.cs
@@ -1,0 +1,13 @@
+﻿namespace Structurizr.CoreTests.MyApp
+{
+    public class MyClass : CodeElement
+    {
+        public MyClass() : base(typeof(MyClass).AssemblyQualifiedName)
+
+        {
+            Name = "My class";
+            Description =
+                "For classes, custom CodeElement subclasses will probably not make much sense. Nevertheless, for consistency overriding should be possible here as well.";
+        }
+    }
+}

--- a/Structurizr.CoreTests/Model/MyApp/MyComponent.cs
+++ b/Structurizr.CoreTests/Model/MyApp/MyComponent.cs
@@ -1,0 +1,11 @@
+﻿namespace Structurizr.CoreTests.MyApp
+{
+    public class MyComponent : Component
+    {
+        public MyComponent()
+        {
+            Name = "My component";
+            Description = "Helps doing useful things";
+        }
+    }
+}

--- a/Structurizr.CoreTests/Model/MyApp/MyContainer.cs
+++ b/Structurizr.CoreTests/Model/MyApp/MyContainer.cs
@@ -1,0 +1,12 @@
+﻿namespace Structurizr.CoreTests.MyApp
+{
+    public class MyContainer : Container
+    {
+        public MyContainer()
+        {
+            Name = "My container";
+            Description = "Helps doing useful things";
+            Technology = ".NET Core";
+        }
+    }
+}

--- a/Structurizr.CoreTests/Model/MyApp/MySoftwareSystem.cs
+++ b/Structurizr.CoreTests/Model/MyApp/MySoftwareSystem.cs
@@ -1,0 +1,11 @@
+﻿namespace Structurizr.CoreTests.MyApp
+{
+    public class MySoftwareSystem : SoftwareSystem
+    {
+        public MySoftwareSystem()
+        {
+            Name = "My System";
+            Description = "Does useful things";
+        }
+    }
+}

--- a/Structurizr.CoreTests/Model/SoftwareSystemTests.cs
+++ b/Structurizr.CoreTests/Model/SoftwareSystemTests.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Structurizr.CoreTests.MyApp;
+
+namespace Structurizr.CoreTests
+{
+    [TestClass]
+    public class SoftwareSystemTests
+    {
+
+        private Workspace workspace;
+        private Model model;
+        private SoftwareSystem softwareSystem;
+
+        public SoftwareSystemTests()
+        {
+            workspace = new Workspace("Name", "Description");
+            model = workspace.Model;
+            softwareSystem = model.AddSoftwareSystem("System", "Description");
+        }
+
+        [TestMethod]
+        public void Test_Adding_A_Container_Adds_It_To_The_List_Of_Containers()
+        {
+            MyContainer myContainer = new MyContainer();
+            softwareSystem.AddContainer(myContainer);
+
+            Assert.IsTrue(softwareSystem.Containers.Contains(myContainer));
+        }
+
+        [TestMethod]
+        public void Test_Adding_A_Container__Does_Not_Add_It_To_The_List_Of_Containers_If_A_Container_With_The_Same_Name_Exists()
+        {
+            MyContainer myContainer = new MyContainer();
+            MyContainer myContainer2 = new MyContainer();
+            softwareSystem.AddContainer(myContainer);
+            softwareSystem.AddContainer(myContainer2);
+
+            Assert.IsFalse(softwareSystem.Containers.Contains(myContainer2));
+        }
+
+    }
+}

--- a/Structurizr.CoreTests/Structurizr.CoreTests.csproj
+++ b/Structurizr.CoreTests/Structurizr.CoreTests.csproj
@@ -64,7 +64,12 @@
     <Compile Include="Documentation\DocumentationTests.cs" />
     <Compile Include="Encryption\AesEncryptionStrategyTests.cs" />
     <Compile Include="Model\CodeElementTests.cs" />
+    <Compile Include="Model\SoftwareSystemTests.cs" />
     <Compile Include="Model\ElementTests.cs" />
+    <Compile Include="Model\MyApp\MyClass.cs" />
+    <Compile Include="Model\MyApp\MyComponent.cs" />
+    <Compile Include="Model\MyApp\MyContainer.cs" />
+    <Compile Include="Model\MyApp\MySoftwareSystem.cs" />
     <Compile Include="Model\PersonTests.cs" />
     <Compile Include="Model\ComponentTests.cs" />
     <Compile Include="Model\ContainerTests.cs" />


### PR DESCRIPTION
It should be possible to create custom subclasses of Model classes like "SoftwareSystem" or "Container" and add instances of those subclasses to the architecture model. This allows for better customization in how the structurizr library can be used.

One of the use cases I imagine implementing is using the fact that a C4 model also documents technology choices for implementing an "architecture as code" / "infrastructure as code" solution. An architectural model implemented like the one shown below could not only be used to generate architecture diagrams, but also to instantiate the described containers in physical (or virtual) infrastructure, such as cloud services (if annotated with additional information).

public class AzureWebApp : Container
{
    public AzureWebApp ()
    {
        this.Technology = "Azure Web App"
    }
}

public class PetClinicWebApp : AzureWebApp
{
    public PetClinicWebApp ()
    {
        this.Name= "Pet Clinic"
    }
}