### PR TITLE
Bump target framework for Roslyn assembly

### DIFF
--- a/Structurizr.Roslyn/Structurizr.Roslyn.csproj
+++ b/Structurizr.Roslyn/Structurizr.Roslyn.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Structurizr.Roslyn</RootNamespace>
     <AssemblyName>Structurizr.Roslyn</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Structurizr.Roslyn/app.config
+++ b/Structurizr.Roslyn/app.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -28,4 +28,7 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+  </startup>
 </configuration>


### PR DESCRIPTION
Despite claims in the Roslyn 1.3.0 NuGet packages that .NET Framework 4.5 is good enough, the referenced assemblies fail to provide the classes used in the Structurizr.Roslyn assembly. We need to pick a framework version that supports .NET Standard 1.3, and that's v4.6 at a minimum.