### PR TITLE
Add Cecil-based component finder strategy

### DIFF
--- a/Structurizr.Cecil/Analysis/CecilTypeRepository.cs
+++ b/Structurizr.Cecil/Analysis/CecilTypeRepository.cs
@@ -1,0 +1,199 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+using Structurizr.Cecil;
+
+namespace Structurizr.Analysis
+{
+    public class CecilTypeRepository : ITypeRepository
+    {
+
+        private readonly AssemblyDefinition _assembly;
+        private readonly string _namespace;
+        private readonly HashSet<Regex> _exclusions = new HashSet<Regex>();
+        private readonly Dictionary<string, TypeDefinition> _types = new Dictionary<string, TypeDefinition>();
+        private readonly Dictionary<string, IEnumerable<string>> _referencedTypesCache = new Dictionary<string, IEnumerable<string>>();
+
+        /// <inheritdoc />
+        public string Namespace { get { return _namespace; } }
+
+        public CecilTypeRepository(AssemblyDefinition assembly, string namespaceName, HashSet<Regex> exclusions)
+        {
+            _assembly = assembly;
+            _namespace = namespaceName;
+
+            if (exclusions != null)
+            {
+                _exclusions.UnionWith(exclusions);
+            }
+
+            IEnumerable<TypeDefinition> types = from a in assembly.EnumerateReferencedAssemblies()
+                                                from m in a.Modules
+                                                from t in m.Types
+                                                where InNamespace(t)
+                                                select t;
+
+            foreach (TypeDefinition type in types)
+            {
+                string assemblyQualifiedName = type.GetAssemblyQualifiedName();
+                if (assemblyQualifiedName != null)
+                {
+                    _types.Add(assemblyQualifiedName, type);
+                }
+            }
+        }
+
+        private bool InNamespace(TypeReference type)
+        {
+            return type.Namespace != null
+                && (
+                    type.Namespace == _namespace
+                    || string.IsNullOrEmpty(_namespace)
+                    || type.Namespace.StartsWith(_namespace + ".")
+                );
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<TypeDefinition> GetAllTypes()
+        {
+            return _types.Values;
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<string> GetReferencedTypes(string typeName)
+        {
+            // use the cached version if possible
+            if (_referencedTypesCache.ContainsKey(typeName))
+            {
+                return _referencedTypesCache[typeName];
+            }
+
+            HashSet<string> referencedTypes = new HashSet<string>();
+            TypeDefinition type;
+            if (_types.TryGetValue(typeName, out type) && type != null)
+            {
+                foreach (PropertyDefinition propertyDefinition in type.Properties)
+                {
+                    AddReferencedTypeIfNotExcluded(propertyDefinition.PropertyType, referencedTypes);
+                }
+
+                foreach (FieldDefinition fieldDefinition in type.Fields)
+                {
+                    AddReferencedTypeIfNotExcluded(fieldDefinition.FieldType, referencedTypes);
+                }
+
+                foreach (MethodDefinition methodDefinition in type.Methods)
+                {
+                    AddReferencedTypeIfNotExcluded(methodDefinition.ReturnType, referencedTypes);
+
+                    foreach (ParameterDefinition parameterDefinition in methodDefinition.Parameters)
+                    {
+                        AddReferencedTypeIfNotExcluded(parameterDefinition.ParameterType, referencedTypes);
+                    }
+
+                    MethodBody methodBody = methodDefinition.Body;
+                    if (methodBody != null)
+                    {
+                        foreach (VariableDefinition variableDefinition in methodBody.Variables)
+                        {
+                            // TODO: skip variables where type is marked with CompilerGeneratedAttribute
+                            AddReferencedTypeIfNotExcluded(variableDefinition.VariableType, referencedTypes);
+                        }
+                    }
+                }
+            }
+
+            // cache for next time
+            _referencedTypesCache[typeName] = referencedTypes;
+
+            return referencedTypes;
+        }
+
+        private void AddReferencedTypeIfNotExcluded(TypeReference type, HashSet<string> referencedTypes)
+        {
+            var assemblyQualifiedName = type.GetAssemblyQualifiedName();
+            if (assemblyQualifiedName != null)
+            {
+                if (!IsExcluded(assemblyQualifiedName))
+                {
+                    referencedTypes.Add(assemblyQualifiedName);
+                }
+
+                if (type.IsGenericInstance)
+                {
+                    var genericInstance = (GenericInstanceType)type;
+                    foreach (TypeReference genericArgumentType in genericInstance.GenericArguments)
+                    {
+                        AddReferencedTypeIfNotExcluded(genericArgumentType, referencedTypes);
+                    }
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public string FindVisibility(string typeName)
+        {
+            TypeDefinition type = _types[typeName];
+            if (type != null)
+            {
+                if (type.IsPublic)
+                {
+                    return "public";
+                }
+                else if (type.IsNestedAssembly)
+                {
+                    return "internal";
+                }
+            }
+
+            // todo
+            return null;
+        }
+
+        /// <inheritdoc />
+        public string FindCategory(string typeName)
+        {
+            TypeDefinition type = _types[typeName];
+            if (type != null)
+            {
+                if (type.IsAbstract)
+                {
+                    if (type.IsSealed)
+                    {
+                        return "static class";
+                    }
+
+                    return "abstract class";
+                }
+                else if (type.IsInterface)
+                {
+                    return "interface";
+                }
+                else if (type.IsEnum)
+                {
+                    return "enum";
+                }
+            }
+
+            // todo
+            return null;
+        }
+
+        private bool IsExcluded(string typeName)
+        {
+            foreach (Regex exclude in _exclusions)
+            {
+                if (exclude.IsMatch(typeName))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Structurizr.Cecil/Analysis/CustomAttributeTypeMatcher.cs
+++ b/Structurizr.Cecil/Analysis/CustomAttributeTypeMatcher.cs
@@ -1,0 +1,40 @@
+﻿using System.Linq;
+
+using Mono.Cecil;
+
+namespace Structurizr.Analysis
+{
+    public class CustomAttributeTypeMatcher : ITypeMatcher
+    {
+        public TypeDefinition AttributeType { get; private set; }
+        public string Description { get; private set; }
+        public string Technology { get; private set; }
+
+        public CustomAttributeTypeMatcher(TypeDefinition attributeType,
+            string description,
+            string technology)
+        {
+            this.AttributeType = attributeType;
+            this.Description = description;
+            this.Technology = technology;
+        }
+
+        /// <inheritdoc />
+        public bool Matches(TypeDefinition type)
+        {
+            return type.CustomAttributes.Any(ca => ca.AttributeType.Resolve().MetadataToken == this.AttributeType.MetadataToken);
+        }
+
+        /// <inheritdoc />
+        public string GetDescription()
+        {
+            return this.Description;
+        }
+
+        /// <inheritdoc />
+        public string GetTechnology()
+        {
+            return this.Technology;
+        }
+    }
+}

--- a/Structurizr.Cecil/Analysis/ExtendsClassTypeMatcher.cs
+++ b/Structurizr.Cecil/Analysis/ExtendsClassTypeMatcher.cs
@@ -1,0 +1,38 @@
+﻿using Mono.Cecil;
+
+using Structurizr.Cecil;
+
+namespace Structurizr.Analysis
+{
+    public class ExtendsClassTypeMatcher : ITypeMatcher
+    {
+        public TypeDefinition ClassType { get; private set; }
+        public string Description { get; private set; }
+        public string Technology { get; private set; }
+
+        public ExtendsClassTypeMatcher(TypeDefinition classType, string description, string technology)
+        {
+            this.ClassType = classType;
+            this.Description = description;
+            this.Technology = technology;
+        }
+
+        /// <inheritdoc />
+        public bool Matches(TypeDefinition type)
+        {
+            return type.IsSubclassOf(this.ClassType);
+        }
+
+        /// <inheritdoc />
+        public string GetDescription()
+        {
+            return this.Description;
+        }
+
+        /// <inheritdoc />
+        public string GetTechnology()
+        {
+            return this.Technology;
+        }
+    }
+}

--- a/Structurizr.Cecil/Analysis/ITypeMatcher.cs
+++ b/Structurizr.Cecil/Analysis/ITypeMatcher.cs
@@ -1,0 +1,13 @@
+﻿using Mono.Cecil;
+
+namespace Structurizr.Analysis
+{
+    public interface ITypeMatcher
+    {
+        bool Matches(TypeDefinition type);
+
+        string GetDescription();
+
+        string GetTechnology();
+    }
+}

--- a/Structurizr.Cecil/Analysis/ITypeRepository.cs
+++ b/Structurizr.Cecil/Analysis/ITypeRepository.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+using Mono.Cecil;
+
+namespace Structurizr.Analysis
+{
+    public interface ITypeRepository
+    {
+        string Namespace { get; }
+        IEnumerable<TypeDefinition> GetAllTypes();
+        IEnumerable<string> GetReferencedTypes(string type);
+
+        string FindCategory(string typeName);
+        string FindVisibility(string typeName);
+    }
+}

--- a/Structurizr.Cecil/Analysis/InterfaceImplementationTypeMatcher.cs
+++ b/Structurizr.Cecil/Analysis/InterfaceImplementationTypeMatcher.cs
@@ -1,0 +1,40 @@
+﻿using Mono.Cecil;
+
+using Structurizr.Cecil;
+
+namespace Structurizr.Analysis
+{
+    public class InterfaceImplementationTypeMatcher : ITypeMatcher
+    {
+        public TypeDefinition InterfaceType { get; private set; }
+        public string Description { get; private set; }
+        public string Technology { get; private set; }
+
+        public InterfaceImplementationTypeMatcher(TypeDefinition interfaceType,
+            string description,
+            string technology)
+        {
+            this.InterfaceType = interfaceType;
+            this.Description = description;
+            this.Technology = technology;
+        }
+
+        /// <inheritdoc />
+        public bool Matches(TypeDefinition type)
+        {
+            return this.InterfaceType.IsAssignableFrom(type);
+        }
+
+        /// <inheritdoc />
+        public string GetDescription()
+        {
+            return this.Description;
+        }
+
+        /// <inheritdoc />
+        public string GetTechnology()
+        {
+            return this.Technology;
+        }
+    }
+}

--- a/Structurizr.Cecil/Analysis/NameSuffixTypeMatcher.cs
+++ b/Structurizr.Cecil/Analysis/NameSuffixTypeMatcher.cs
@@ -1,0 +1,36 @@
+﻿using Mono.Cecil;
+
+namespace Structurizr.Analysis
+{
+    public class NameSuffixTypeMatcher : ITypeMatcher
+    {
+        public string Suffix { get; private set; }
+        public string Description { get; private set; }
+        public string Technology { get; private set; }
+
+        public NameSuffixTypeMatcher(string suffix, string description, string technology)
+        {
+            this.Suffix = suffix;
+            this.Description = description;
+            this.Technology = technology;
+        }
+
+        /// <inheritdoc />
+        public bool Matches(TypeDefinition type)
+        {
+            return type.Name.EndsWith(this.Suffix);
+        }
+
+        /// <inheritdoc />
+        public string GetDescription()
+        {
+            return this.Description;
+        }
+
+        /// <inheritdoc />
+        public string GetTechnology()
+        {
+            return this.Technology;
+        }
+    }
+}

--- a/Structurizr.Cecil/Analysis/SupportingTypes/ReferencedTypesSupportingTypesStrategy.cs
+++ b/Structurizr.Cecil/Analysis/SupportingTypes/ReferencedTypesSupportingTypesStrategy.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Structurizr.Analysis.SupportingTypes
+{
+    class ReferencedTypesSupportingTypesStrategy : SupportingTypesStrategy
+    {
+        private bool _includeIndirectlyReferencedTypes;
+
+        public ReferencedTypesSupportingTypesStrategy() : this(true)
+        {
+        }
+
+        public ReferencedTypesSupportingTypesStrategy(bool includeIndirectlyReferencedTypes)
+        {
+            _includeIndirectlyReferencedTypes = includeIndirectlyReferencedTypes;
+        }
+
+        /// <inheritdoc />
+        public override HashSet<string> FindSupportingTypes(Component component)
+        {
+            HashSet<string> referencedTypes = new HashSet<string>();
+            referencedTypes.UnionWith(GetReferencedTypesInNamespace(component.Type));
+
+            foreach (CodeElement codeElement in component.CodeElements)
+            {
+                referencedTypes.UnionWith(GetReferencedTypesInNamespace(codeElement.Type));
+            }
+
+            if (_includeIndirectlyReferencedTypes)
+            {
+                int numberOfTypes = referencedTypes.Count;
+                bool foundMore = true;
+                while (foundMore)
+                {
+                    HashSet<string> indirectlyReferencedTypes = new HashSet<string>();
+                    foreach (string type in referencedTypes)
+                    {
+                        indirectlyReferencedTypes.UnionWith(GetReferencedTypesInNamespace(type));
+                    }
+                    referencedTypes.UnionWith(indirectlyReferencedTypes);
+
+                    if (referencedTypes.Count > numberOfTypes)
+                    {
+                        foundMore = true;
+                        numberOfTypes = referencedTypes.Count;
+                    }
+                    else
+                    {
+                        foundMore = false;
+                    }
+                }
+            }
+
+            return referencedTypes;
+        }
+
+        private IEnumerable<string> GetReferencedTypesInNamespace(string typeName)
+        {
+            IEnumerable<string> referencedTypes = TypeRepository.GetReferencedTypes(typeName);
+            return referencedTypes.Where(t => t.StartsWith(TypeRepository.Namespace));
+        }
+    }
+}

--- a/Structurizr.Cecil/Analysis/SupportingTypes/SupportingTypesStrategy.cs
+++ b/Structurizr.Cecil/Analysis/SupportingTypes/SupportingTypesStrategy.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace Structurizr.Analysis
+{
+    public abstract class SupportingTypesStrategy
+    {
+
+        protected internal ITypeRepository TypeRepository { get; internal set; }
+
+        public abstract HashSet<string> FindSupportingTypes(Component component);
+
+    }
+}

--- a/Structurizr.Cecil/Analysis/TypeMatcherComponentFinderStrategy.cs
+++ b/Structurizr.Cecil/Analysis/TypeMatcherComponentFinderStrategy.cs
@@ -1,0 +1,138 @@
+﻿using System.Collections.Generic;
+
+using Mono.Cecil;
+
+using Structurizr.Cecil;
+
+namespace Structurizr.Analysis
+{
+    public class TypeMatcherComponentFinderStrategy : ComponentFinderStrategy
+    {
+        /// <inheritdoc />
+        public ComponentFinder ComponentFinder { get; set; }
+
+        private HashSet<Component> _componentsFound = new HashSet<Component>();
+
+        private AssemblyDefinition _primaryAssembly;
+        private ITypeRepository _typeRepository;
+        private List<ITypeMatcher> _typeMatchers = new List<ITypeMatcher>();
+        private List<SupportingTypesStrategy> _supportingTypesStrategies = new List<SupportingTypesStrategy>();
+
+        public TypeMatcherComponentFinderStrategy(AssemblyDefinition assembly,
+            params ITypeMatcher[] typeMatchers)
+        {
+            this._primaryAssembly = assembly;
+            this._typeMatchers.AddRange(typeMatchers);
+        }
+
+        /// <inheritdoc />
+        public void BeforeFindComponents()
+        {
+            _typeRepository = new CecilTypeRepository(
+                _primaryAssembly,
+                ComponentFinder.Namespace,
+                ComponentFinder.Exclusions);
+            foreach (SupportingTypesStrategy strategy in _supportingTypesStrategies)
+            {
+                strategy.TypeRepository = _typeRepository;
+            }
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<Component> FindComponents()
+        {
+            foreach (TypeDefinition type in _typeRepository.GetAllTypes())
+            {
+                foreach (ITypeMatcher typeMatcher in this._typeMatchers)
+                {
+                    if (typeMatcher.Matches(type))
+                    {
+                        Component component = ComponentFinder.Container.AddComponent(
+                            type.Name,
+                            type.GetAssemblyQualifiedName(),
+                            typeMatcher.GetDescription(),
+                            typeMatcher.GetTechnology());
+                        _componentsFound.Add(component);
+                    }
+                }
+            }
+
+            return _componentsFound;
+        }
+
+        /// <inheritdoc />
+        public void AfterFindComponents()
+        {
+            // before finding dependencies, let's find the types that are used to implement each component
+            foreach (Component component in _componentsFound)
+            {
+                foreach (CodeElement codeElement in component.CodeElements)
+                {
+                    codeElement.Visibility = _typeRepository.FindVisibility(codeElement.Type);
+                    codeElement.Category = _typeRepository.FindCategory(codeElement.Type);
+                }
+
+                foreach (SupportingTypesStrategy strategy in _supportingTypesStrategies)
+                {
+                    foreach (string type in strategy.FindSupportingTypes(component))
+                    {
+                        if (ComponentFinder.Container.GetComponentOfType(type) == null)
+                        {
+                            CodeElement codeElement = component.AddSupportingType(type);
+                            codeElement.Visibility = _typeRepository.FindVisibility(type);
+                            codeElement.Category = _typeRepository.FindCategory(type);
+                        }
+                    }
+                }
+            }
+
+            foreach (Component component in ComponentFinder.Container.Components)
+            {
+                if (component.Type != null)
+                {
+                    AddEfferentDependencies(component, component.Type, new HashSet<string>());
+
+                    // and repeat for the supporting types
+                    foreach (CodeElement codeElement in component.CodeElements)
+                    {
+                        AddEfferentDependencies(component, codeElement.Type, new HashSet<string>());
+                    }
+                }
+            }
+        }
+
+        private void AddEfferentDependencies(Component component, string type, HashSet<string> typesVisited)
+        {
+            typesVisited.Add(type);
+
+            foreach (string referencedTypeName in _typeRepository.GetReferencedTypes(type))
+            {
+                Component destinationComponent = ComponentFinder.Container.GetComponentOfType(referencedTypeName);
+                if (destinationComponent != null)
+                {
+                    if (component != destinationComponent)
+                    {
+                        component.Uses(destinationComponent, "");
+                    }
+                }
+                else if (!typesVisited.Contains(referencedTypeName))
+                {
+                    AddEfferentDependencies(component, referencedTypeName, typesVisited);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Adds a CecilSupportingTypesStrategy.
+        /// </summary>
+        /// <param name="strategy">A CecilSupportingTypesStrategy object</param>
+        public void AddSupportingTypesStrategy(SupportingTypesStrategy strategy)
+        {
+            if (strategy != null)
+            {
+                _supportingTypesStrategies.Add(strategy);
+                strategy.TypeRepository = _typeRepository;
+            }
+        }
+    }
+}

--- a/Structurizr.Cecil/Structurizr.Cecil.csproj
+++ b/Structurizr.Cecil/Structurizr.Cecil.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Mono.Cecil" Version="0.10.0-beta6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Structurizr.Core\Structurizr.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Structurizr.Cecil/Util/AssemblyDefinitionExtensions.cs
+++ b/Structurizr.Cecil/Util/AssemblyDefinitionExtensions.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+using Mono.Cecil;
+
+namespace Structurizr.Cecil
+{
+    public static class AssemblyDefinitionExtensions
+    {
+        public static IEnumerable<AssemblyDefinition> EnumerateReferencedAssemblies(this AssemblyDefinition assembly,
+            bool includeSelf = true)
+        {
+            var references = new HashSet<MetadataToken>();
+
+            var queue = new Queue<AssemblyDefinition>();
+            queue.Enqueue(assembly);
+
+            if (includeSelf)
+            {
+                yield return assembly;
+            }
+
+            while (queue.Count > 0)
+            {
+                var assm = queue.Dequeue();
+
+                if (references.Contains(assm.MetadataToken)) continue;
+                references.Add(assm.MetadataToken);
+
+                var refs = from m in assm.Modules from r in m.AssemblyReferences select r;
+                foreach (var r in refs)
+                {
+                    AssemblyDefinition refAssm;
+                    try
+                    {
+                        refAssm = assembly.MainModule.AssemblyResolver.Resolve(r);
+                        queue.Enqueue(refAssm);
+                    }
+                    catch (AssemblyResolutionException e)
+                    {
+                        Debug.WriteLine(e);
+                        refAssm = null;
+                    }
+
+                    if (refAssm != null)
+                        yield return refAssm;
+                }
+            }
+        }
+    }
+}

--- a/Structurizr.Cecil/Util/TypeDefinitionExtensions.cs
+++ b/Structurizr.Cecil/Util/TypeDefinitionExtensions.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+using Mono.Cecil;
+
+namespace Structurizr.Cecil
+{
+    /// <remarks>
+    /// Sourced from https://stackoverflow.com/questions/40018991/how-to-implement-isassignablefrom-with-mono-cecil
+    /// </remarks>
+    public static class TypeDefinitionExtensions
+    {
+        /// <summary>
+        /// Is childTypeDef a subclass of parentTypeDef. Does not test interface inheritance
+        /// </summary>
+        /// <param name="childTypeDef"></param>
+        /// <param name="parentTypeDef"></param>
+        /// <returns></returns>
+        public static bool IsSubclassOf(this TypeDefinition childTypeDef, TypeDefinition parentTypeDef) =>
+            childTypeDef.MetadataToken
+            != parentTypeDef.MetadataToken
+            && childTypeDef
+                .EnumerateBaseClasses()
+                .Any(b => b.MetadataToken == parentTypeDef.MetadataToken);
+
+        /// <summary>
+        /// Does childType inherit from parentInterface
+        /// </summary>
+        /// <param name="childType"></param>
+        /// <param name="parentInterfaceDef"></param>
+        /// <returns></returns>
+        public static bool DoesAnySubTypeImplementInterface(this TypeDefinition childType, TypeDefinition parentInterfaceDef)
+        {
+            Debug.Assert(parentInterfaceDef.IsInterface);
+            return childType
+                .EnumerateBaseClasses()
+                .Any(typeDefinition => typeDefinition.DoesSpecificTypeImplementInterface(parentInterfaceDef));
+        }
+
+        /// <summary>
+        /// Does the childType directly inherit from parentInterface. Base
+        /// classes of childType are not tested
+        /// </summary>
+        /// <param name="childTypeDef"></param>
+        /// <param name="parentInterfaceDef"></param>
+        /// <returns></returns>
+        public static bool DoesSpecificTypeImplementInterface(this TypeDefinition childTypeDef, TypeDefinition parentInterfaceDef)
+        {
+            Debug.Assert(parentInterfaceDef.IsInterface);
+            return childTypeDef
+                .Interfaces
+                .Any(ifaceDef => DoesSpecificInterfaceImplementInterface(ifaceDef.InterfaceType.Resolve(), parentInterfaceDef));
+        }
+
+        /// <summary>
+        /// Does interface iface0 equal or implement interface iface1
+        /// </summary>
+        /// <param name="iface0"></param>
+        /// <param name="iface1"></param>
+        /// <returns></returns>
+        public static bool DoesSpecificInterfaceImplementInterface(TypeDefinition iface0, TypeDefinition iface1)
+        {
+            Debug.Assert(iface1.IsInterface);
+            Debug.Assert(iface0.IsInterface);
+            return iface0.MetadataToken == iface1.MetadataToken || iface0.DoesAnySubTypeImplementInterface(iface1);
+        }
+
+        /// <summary>
+        /// Is source type assignable to target type
+        /// </summary>
+        /// <param name="target"></param>
+        /// <param name="source"></param>
+        /// <returns></returns>
+        public static bool IsAssignableFrom(this TypeDefinition target, TypeDefinition source)
+            => target == source
+                || target.MetadataToken == source.MetadataToken
+                || source.IsSubclassOf(target)
+                || target.IsInterface && source.DoesAnySubTypeImplementInterface(target);
+
+        /// <summary>
+        /// Enumerate the current type, it's parent and all the way to the top type
+        /// </summary>
+        /// <param name="klassType"></param>
+        /// <returns></returns>
+        public static IEnumerable<TypeDefinition> EnumerateBaseClasses(this TypeDefinition klassType)
+        {
+            for (var typeDefinition = klassType; typeDefinition != null; typeDefinition = typeDefinition.BaseType?.Resolve())
+            {
+                yield return typeDefinition;
+            }
+        }
+    }
+}

--- a/Structurizr.Cecil/Util/TypeReferenceExtensions.cs
+++ b/Structurizr.Cecil/Util/TypeReferenceExtensions.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Linq;
+
+using Mono.Cecil;
+
+namespace Structurizr.Cecil
+{
+    public static class TypeReferenceExtensions
+    {
+        public static string GetAssemblyQualifiedName(this TypeReference type)
+        {
+            string typeName;
+
+            if (type.IsGenericInstance)
+            {
+                var genericInstance = (GenericInstanceType)type;
+                typeName = String.Format("{0}.{1}[{2}]",
+                    genericInstance.Namespace,
+                    type.Name,
+                    String.Join(",",
+                        genericInstance.GenericArguments.Select(p => p.GetAssemblyQualifiedName()).ToArray()
+                ));
+            }
+            else
+            {
+                typeName = type.FullName;
+            }
+
+            var scope = type.Scope as AssemblyNameReference;
+            if (scope != null)
+            {
+                return typeName + ", " + scope.FullName;
+            }
+            else if (type.Scope != null)
+            {
+                return typeName + ", " + type.Module.Assembly.FullName;
+            }
+
+            return typeName;
+        }
+    }
+}

--- a/Structurizr.sln
+++ b/Structurizr.sln
@@ -39,6 +39,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Structurizr.Roslyn", "Struc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Structurizr.Reflection.Examples", "Structurizr.Reflection.Examples\Structurizr.Reflection.Examples.csproj", "{7608B23C-2ACA-4C00-9186-F304137FABB9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Structurizr.Cecil", "Structurizr.Cecil\Structurizr.Cecil.csproj", "{F7E8ECD8-6C01-4A35-A270-D78576C38694}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +71,10 @@ Global
 		{7608B23C-2ACA-4C00-9186-F304137FABB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7608B23C-2ACA-4C00-9186-F304137FABB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7608B23C-2ACA-4C00-9186-F304137FABB9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F7E8ECD8-6C01-4A35-A270-D78576C38694}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F7E8ECD8-6C01-4A35-A270-D78576C38694}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F7E8ECD8-6C01-4A35-A270-D78576C38694}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F7E8ECD8-6C01-4A35-A270-D78576C38694}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Mostly matches the API defined by the Reflection based finder, but uses Mono.Cecil and its type types instead of using System.Type for everything. With the exception of `ITypeRepository` (the interface is just `TypeRepository` in the Reflection component finder) the type names are the same, including namespace.

A collection of helper methods are available in the Util directory. Since these methods mostly provide analogues to methods available on System.Type, they are made public in order to aid anyone making use of the component finder.

Fixes #10 