### PR TITLE
Cecil Fix: Compare metadata token AND module MVID together for type equality checks

### DIFF
--- a/Structurizr.Cecil/Util/TypeDefinitionExtensions.cs
+++ b/Structurizr.Cecil/Util/TypeDefinitionExtensions.cs
@@ -18,11 +18,10 @@ namespace Structurizr.Cecil
         /// <param name="parentTypeDef"></param>
         /// <returns></returns>
         public static bool IsSubclassOf(this TypeDefinition childTypeDef, TypeDefinition parentTypeDef) =>
-            childTypeDef.MetadataToken
-            != parentTypeDef.MetadataToken
+            (childTypeDef.MetadataToken != parentTypeDef.MetadataToken || childTypeDef.Module.Mvid != parentTypeDef.Module.Mvid)
             && childTypeDef
                 .EnumerateBaseClasses()
-                .Any(b => b.MetadataToken == parentTypeDef.MetadataToken);
+                .Any(b => b.MetadataToken == parentTypeDef.MetadataToken && b.Module.Mvid == parentTypeDef.Module.Mvid);
 
         /// <summary>
         /// Does childType inherit from parentInterface
@@ -63,7 +62,8 @@ namespace Structurizr.Cecil
         {
             Debug.Assert(iface1.IsInterface);
             Debug.Assert(iface0.IsInterface);
-            return iface0.MetadataToken == iface1.MetadataToken || iface0.DoesAnySubTypeImplementInterface(iface1);
+            return (iface0.MetadataToken == iface1.MetadataToken && iface0.Module.Mvid == iface1.Module.Mvid)
+                || iface0.DoesAnySubTypeImplementInterface(iface1);
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace Structurizr.Cecil
         /// <returns></returns>
         public static bool IsAssignableFrom(this TypeDefinition target, TypeDefinition source)
             => target == source
-                || target.MetadataToken == source.MetadataToken
+                || (target.MetadataToken == source.MetadataToken && target.Module.Mvid == source.Module.Mvid)
                 || source.IsSubclassOf(target)
                 || target.IsInterface && source.DoesAnySubTypeImplementInterface(target);
 


### PR DESCRIPTION
Fix for false positives when checking if two types are the same (used in subclass or interface implementation checks).

Metadata tokens are only guaranteed to be unique within a single module. We need to ensure that the modules are the same when metadata tokens are the same, and we can do that with the MVID value since it's a globally unique value created every time a module is built.