### PR TITLE
set custom element property on inner property dictionary

### DIFF
--- a/Structurizr.Core/Model/Element.cs
+++ b/Structurizr.Core/Model/Element.cs
@@ -164,7 +164,7 @@ namespace Structurizr
                 throw new ArgumentException("A property value must be specified.");
             }
 
-            Properties[name] = value;
+            _properties[name] = value;
         }
 
         public override string ToString()


### PR DESCRIPTION
Calling the `Properties` property getter returns a new dictionary, which ultimately reduces `AddProperty` to an expensive no-op. To fix this, we'll instead use the index setter on the inner `_properties` collection instead of its clones.