### PR TITLE
Annotations for .NET

### DIFF
--- a/Structurizr.Annotations/CodeElementAttribute.cs
+++ b/Structurizr.Annotations/CodeElementAttribute.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Structurizr.Annotations
+{
+    /// <summary>
+    /// Specifies that the attributed type class or interface can be considered to be a "component".
+    /// </summary>
+    [AttributeUsage(
+        AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct,
+        Inherited = false,
+        AllowMultiple = false)]
+    public sealed class CodeElementAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets the name of the component to which the attributed type belongs.
+        /// </summary>
+        /// <value>The name of the component which includes the attributed type.</value>
+        public string ComponentName { get; }
+
+        /// <summary>
+        /// Gets or sets a description of the code element.
+        /// </summary>
+        /// <value>A description of the code element.</value>
+        public string Description { get; set; } = String.Empty;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ComponentAttribute"/> class.
+        /// </summary>
+        public CodeElementAttribute(string componentName) {
+            if (String.IsNullOrWhiteSpace(componentName))
+                throw new ArgumentNullException(nameof(componentName));
+            this.ComponentName = componentName;
+        }
+    }
+}

--- a/Structurizr.Annotations/ComponentAttribute.cs
+++ b/Structurizr.Annotations/ComponentAttribute.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace Structurizr.Annotations
+{
+    /// <summary>
+    /// Specifies that the attributed type class or interface can be considered to be a "component".
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, Inherited = false, AllowMultiple = false)]
+    public sealed class ComponentAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets or sets a description of the component.
+        /// </summary>
+        /// <value>A description of the component.</value>
+        public string Description { get; set; } = String.Empty;
+
+        /// <summary>
+        /// Gets or sets a description of the technology used to implement the component.
+        /// </summary>
+        /// <value>A description of the technology used to implement the component.</value>
+        public string Technology { get; set; } = String.Empty;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ComponentAttribute"/> class.
+        /// </summary>
+        public ComponentAttribute() {}
+    }
+}

--- a/Structurizr.Annotations/Structurizr.Annotations.csproj
+++ b/Structurizr.Annotations/Structurizr.Annotations.csproj
@@ -1,5 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- Update this property group for every regular release -->
+  <PropertyGroup>
+    <VersionPrefix>0.6.0</VersionPrefix>
+    <ReleaseNotes></ReleaseNotes>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Summary>Annotations to maintain the C4 model for software architecture in code</Summary>
+    <Description>Structurizr Annotations lets you use .NET attributes to declare components and their relationships using the C4 model for software architecture.</Description>
+    <Authors>Structurizr Limited</Authors>
+    <Copyright>Copyright 2017</Copyright>
+    <PackageLicenseUrl>https://opensource.org/licenses/Apache-2.0</PackageLicenseUrl>
+    <PackageProjectUrl>https://structurizr.com</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/structurizr/dotnet</RepositoryUrl>
+  </PropertyGroup>
+
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;net40</TargetFrameworks>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Structurizr.Annotations.xml</DocumentationFile>

--- a/Structurizr.Annotations/Structurizr.Annotations.csproj
+++ b/Structurizr.Annotations/Structurizr.Annotations.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.0;net20;portable-net4+sl4+wp7+netcore45;portable-net5+sl50+win8+wpa81+wp8</TargetFrameworks>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Structurizr.Annotations.xml</DocumentationFile>
+    <NetStandardImplicitPackageVersion>1.0.0</NetStandardImplicitPackageVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
+    <PackageReference Include="System.Runtime">
+      <Version>4.1.0</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/Structurizr.Annotations/Structurizr.Annotations.csproj
+++ b/Structurizr.Annotations/Structurizr.Annotations.csproj
@@ -19,7 +19,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;net40</TargetFrameworks>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Structurizr.Annotations.xml</DocumentationFile>
-    <NetStandardImplicitPackageVersion>1.0.0</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">

--- a/Structurizr.Annotations/Structurizr.Annotations.csproj
+++ b/Structurizr.Annotations/Structurizr.Annotations.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;net20;portable-net4+sl4+wp7+netcore45;portable-net5+sl50+win8+wpa81+wp8</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;net40</TargetFrameworks>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Structurizr.Annotations.xml</DocumentationFile>
     <NetStandardImplicitPackageVersion>1.0.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>

--- a/Structurizr.Annotations/UsedByContainerAttribute.cs
+++ b/Structurizr.Annotations/UsedByContainerAttribute.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Structurizr.Annotations
+{
+    /// <summary>
+    /// Specifies that the named container uses the component on which this attribute is placed, creating a relationship
+    /// from the container to the component.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, Inherited = false, AllowMultiple = true)]
+    public sealed class UsedByContainerAttribute : System.Attribute
+    {
+        /// <summary>
+        /// Gets the name of the container which uses the attributed component.
+        /// </summary>
+        /// <value>The name of the container which uses the attributed component.</value>
+        public string ContainerName { get; }
+
+        /// <summary>
+        /// Gets or sets a description of the relationship from the named container to the attributed component.
+        /// </summary>
+        /// <value>A string describing how the named container uses the attributed component.</value>
+        public string Description { get; set; } = "";
+
+        /// <summary>
+        /// Gets or sets a description of the technology used to implement the relationship between the named container
+        /// and the attributed component.
+        /// </summary>
+        /// <value>
+        /// A string describing the technology used for connecting the named container to the attributed component.
+        /// </value>
+        public string Technology { get; set; } = "";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UsedByContainerAttribute"/> class with the name of the
+        /// container using the component specified.
+        /// </summary>
+        /// <param name="containerName">The name of the container which uses the attributed component.</param>
+        public UsedByContainerAttribute(string containerName)
+        {
+            if (String.IsNullOrWhiteSpace(containerName)) throw new ArgumentNullException(nameof(containerName));
+            this.ContainerName = containerName;
+        }
+    }
+}

--- a/Structurizr.Annotations/UsedByPersonAttribute.cs
+++ b/Structurizr.Annotations/UsedByPersonAttribute.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Structurizr.Annotations
+{
+    /// <summary>
+    /// Specifies that the named person uses the component on which this attribute is placed, creating a relationship
+    /// from the person to the component.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, Inherited = false, AllowMultiple = true)]
+    public sealed class UsedByPersonAttribute : System.Attribute
+    {
+        /// <summary>
+        /// Gets the name of the person who uses the attributed component.
+        /// </summary>
+        /// <value>The name of the person who uses the attributed component.</value>
+        public string PersonName { get; }
+
+        /// <summary>
+        /// Gets or sets a description of the relationship from the named person to the attributed component.
+        /// </summary>
+        /// <value>A string describing how the named person uses the attributed component.</value>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets a description of the technology used to implement the relationship between the named person
+        /// and the attributed component.
+        /// </summary>
+        /// <value>
+        /// A string describing the technology used for connecting the named person to the attributed component.
+        /// </value>
+        public string Technology { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UsedByPersonAttribute"/> class with the name of the person
+        /// using the component specified.
+        /// </summary>
+        /// <param name="personName">The name of the person which uses the attributed component.</param>
+        public UsedByPersonAttribute(string personName)
+        {
+            if (String.IsNullOrWhiteSpace(personName)) throw new ArgumentNullException(nameof(personName));
+            this.PersonName = personName;
+        }
+    }
+}

--- a/Structurizr.Annotations/UsedBySoftwareSystemAttribute.cs
+++ b/Structurizr.Annotations/UsedBySoftwareSystemAttribute.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace Structurizr.Annotations
+{
+    /// <summary>
+    /// Specifies that the named software system uses the component on which this attribute is placed, creating a
+    /// relationship from the software system to the component.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, Inherited = false, AllowMultiple = true)]
+    public sealed class UsedBySoftwareSystemAttribute : System.Attribute
+    {
+        /// <summary>
+        /// Gets the name of the software system who uses the attributed component.
+        /// </summary>
+        /// <value>The name of the software system who uses the attributed component.</value>
+        public string SoftwareSystemName { get; }
+
+        /// <summary>
+        /// Gets or sets a description of the relationship from the named software system to the attributed component.
+        /// </summary>
+        /// <value>A string describing how the named software system uses the attributed component.</value>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets a description of the technology used to implement the relationship between the named software
+        /// system and the attributed component.
+        /// </summary>
+        /// <value>
+        /// A string describing the technology used for connecting the named software system to the attributed
+        /// component.
+        /// </value>
+        public string Technology { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UsedBySoftwareSystemAttribute"/> class with the name of the
+        /// software system using the component specified.
+        /// </summary>
+        /// <param name="softwareSystemName">The name of the software system which uses the attributed component.</param>
+        public UsedBySoftwareSystemAttribute(string softwareSystemName)
+        {
+            if (String.IsNullOrWhiteSpace(softwareSystemName))
+                throw new ArgumentNullException(nameof(softwareSystemName));
+            this.SoftwareSystemName = softwareSystemName;
+        }
+    }
+}

--- a/Structurizr.Annotations/UsesComponentAttribute.cs
+++ b/Structurizr.Annotations/UsesComponentAttribute.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace Structurizr.Annotations
+{
+    /// <summary>
+    /// Specifies that the type of the attributed field, property, or parameter is a component used by the type to which
+    /// the attributed field, property, or parameter belongs.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// In documentation for this annotation, the "attributed component" refers to the type containing the field,
+    /// property, or parameter on which the attribute is placed. The "used component" is the component specified by the
+    /// type of the field, property, or parameter.
+    /// </para>
+    /// </remarks>
+    [AttributeUsage(
+        AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter,
+        Inherited = false,
+        AllowMultiple = false)]
+    public sealed class UsesComponentAttribute : System.Attribute
+    {
+        /// <summary>
+        /// Gets a description of the relationship from the attributed component to the used component.
+        /// </summary>
+        /// <value>A string describing how the used component is used by the attributed component.</value>
+        public string Description { get; }
+
+        /// <summary>
+        /// Gets or sets a description of the technology used to implement the relationship between the attributed
+        /// component to the used component.
+        /// </summary>
+        /// <value>
+        /// A string describing the technology used for connecting the attributed component to the used component.
+        /// </value>
+        public string Technology { get; set; } = "";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UsesComponentAttribute"/> class with a description of the
+        /// relationship from the attributed component to the used component.
+        /// </summary>
+        /// <param name="description">
+        /// A string describing how the used component is used by the attributed component.
+        /// </param>
+        public UsesComponentAttribute(string description)
+        {
+            if (String.IsNullOrWhiteSpace(description)) throw new ArgumentNullException(nameof(description));
+            this.Description = description;
+        }
+    }
+}

--- a/Structurizr.Annotations/UsesContainerAttribute.cs
+++ b/Structurizr.Annotations/UsesContainerAttribute.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Structurizr.Annotations
+{
+    /// <summary>
+    /// Specifies that the named container is used by the component on which this attribute is placed, creating a
+    /// relationship from the component to the container.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, Inherited = false, AllowMultiple = true)]
+    public sealed class UsesContainerAttribute : System.Attribute
+    {
+        /// <summary>
+        /// Gets the name of the container used by the attributed component.
+        /// </summary>
+        /// <value>The name of the container which is used by the attributed component.</value>
+        public string ContainerName { get; }
+
+        /// <summary>
+        /// Gets or sets a description of the relationship from the attributed component to the named container.
+        /// </summary>
+        /// <value>A string describing how the named container is used by the attributed component.</value>
+        public string Description { get; set; } = "";
+
+        /// <summary>
+        /// Gets or sets a description of the technology used to implement the relationship between the attributed
+        /// component to the named container.
+        /// </summary>
+        /// <value>
+        /// A string describing the technology used for connecting the attributed component to the named container.
+        /// </value>
+        public string Technology { get; set; } = "";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UsesContainerAttribute"/> class with the name of the
+        /// container being used by the attributed component.
+        /// </summary>
+        /// <param name="containerName">The name of the container which is used by the attributed component.</param>
+        public UsesContainerAttribute(string containerName)
+        {
+            if (String.IsNullOrWhiteSpace(containerName)) throw new ArgumentNullException(nameof(containerName));
+            this.ContainerName = containerName;
+        }
+    }
+}

--- a/Structurizr.Annotations/UsesSoftwareSystemAttribute.cs
+++ b/Structurizr.Annotations/UsesSoftwareSystemAttribute.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace Structurizr.Annotations
+{
+    /// <summary>
+    /// Specifies that the named software system is used by the component on which this attribute is placed, creating a
+    /// relationship from the component to the software system.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, Inherited = false, AllowMultiple = true)]
+    public sealed class UsesSoftwareSystemAttribute : System.Attribute
+    {
+        /// <summary>
+        /// Gets the name of the software system used by the attributed component.
+        /// </summary>
+        /// <value>The name of the software system which is used by the attributed component.</value>
+        public string SoftwareSystemName { get; }
+
+        /// <summary>
+        /// Gets or sets a description of the relationship from the attributed component to the named software system.
+        /// </summary>
+        /// <value>A string describing how the named software system is used by the attributed component.</value>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets a description of the technology used to implement the relationship between the named software
+        /// system and the attributed component.
+        /// </summary>
+        /// <value>
+        /// A string describing the technology used for connecting the attributed component to the named software
+        /// system.
+        /// </value>
+        public string Technology { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UsesSoftwareSystemAttribute"/> class with the name of the
+        /// software system used by the component specified.
+        /// </summary>
+        /// <param name="softwareSystemName">
+        /// The name of the software system which is used by the attributed component.
+        /// </param>
+        public UsesSoftwareSystemAttribute(string softwareSystemName)
+        {
+            if (String.IsNullOrWhiteSpace(softwareSystemName))
+                throw new ArgumentNullException(nameof(softwareSystemName));
+            this.SoftwareSystemName = softwareSystemName;
+        }
+    }
+}

--- a/Structurizr.Cecil.Examples/Annotations/EfRepository.cs
+++ b/Structurizr.Cecil.Examples/Annotations/EfRepository.cs
@@ -1,0 +1,14 @@
+using Structurizr.Annotations;
+
+namespace Structurizr.Examples.Annotations
+{
+    [CodeElement(nameof(IRepository), Description = "Implementation")]
+    [UsesContainer("Database", Description = "Reads from", Technology = "Entity Framework")]
+    class EfRepository : IRepository
+    {
+        public string GetData(long id)
+        {
+            return "...";
+        }
+    }
+}

--- a/Structurizr.Cecil.Examples/Annotations/HtmlController.cs
+++ b/Structurizr.Cecil.Examples/Annotations/HtmlController.cs
@@ -1,0 +1,12 @@
+using Structurizr.Annotations;
+
+namespace Structurizr.Examples.Annotations
+{
+    [Component(Description = "Serves HTML pages to users.", Technology = "ASP.NET MVC")]
+    [UsedByPerson("User", Description = "Uses", Technology = "HTTPS")]
+    class HtmlController
+    {
+        [UsesComponent("Gets data using")]
+        private IRepository repository = new EfRepository();
+    }
+}

--- a/Structurizr.Cecil.Examples/Annotations/IRepository.cs
+++ b/Structurizr.Cecil.Examples/Annotations/IRepository.cs
@@ -1,0 +1,10 @@
+using Structurizr.Annotations;
+
+namespace Structurizr.Examples.Annotations
+{
+    [Component(Description = "Provides access to data stored in the database.", Technology = "C#")]
+    public interface IRepository
+    {
+        string GetData(long id);
+    }
+}

--- a/Structurizr.Cecil.Examples/Structurizr.Cecil.Examples.csproj
+++ b/Structurizr.Cecil.Examples/Structurizr.Cecil.Examples.csproj
@@ -10,6 +10,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="System.Runtime" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Structurizr.Annotations\Structurizr.Annotations.csproj" />
     <ProjectReference Include="..\Structurizr.Cecil\Structurizr.Cecil.csproj" />
     <ProjectReference Include="..\Structurizr.Core\Structurizr.Core.csproj" />

--- a/Structurizr.Cecil.Examples/Structurizr.Cecil.Examples.csproj
+++ b/Structurizr.Cecil.Examples/Structurizr.Cecil.Examples.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net45</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Mono.Cecil" Version="0.10.0-beta6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Structurizr.Annotations\Structurizr.Annotations.csproj" />
+    <ProjectReference Include="..\Structurizr.Cecil\Structurizr.Cecil.csproj" />
+    <ProjectReference Include="..\Structurizr.Core\Structurizr.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Structurizr.Cecil.Examples/StructurizrAnnotations.cs
+++ b/Structurizr.Cecil.Examples/StructurizrAnnotations.cs
@@ -1,0 +1,68 @@
+using System.IO;
+
+using Mono.Cecil;
+
+using Structurizr.Analysis;
+using Structurizr.Api;
+
+namespace Structurizr.Examples
+{
+    public class StructurizrAnnotations
+    {
+        private const string DATABASE_TAG = "Database";
+
+        private const long WorkspaceId = 38339;
+        private const string ApiKey = "key";
+        private const string ApiSecret = "secret";
+
+        static void Main()
+        {
+            Workspace workspace = new Workspace("Structurizr for .NET Annotations", "This is a model of my software system.");
+            Model model = workspace.Model;
+
+            Person user = model.AddPerson("User", "A user of my software system.");
+            SoftwareSystem softwareSystem = model.AddSoftwareSystem("Software System", "My software system.");
+
+            Container webApplication = softwareSystem.AddContainer("Web Application", "Provides users with information.", "C#");
+            Container database = softwareSystem.AddContainer("Database", "Stores information.", "Relational database schema");
+            database.AddTags(DATABASE_TAG);
+
+            string assemblyPath = typeof(StructurizrAnnotations).Assembly.Location;
+            DefaultAssemblyResolver resolver = new DefaultAssemblyResolver();
+            resolver.AddSearchDirectory(Path.GetDirectoryName(assemblyPath));
+            AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(
+                assemblyPath,
+                new ReaderParameters { AssemblyResolver = resolver }
+            );
+
+            ComponentFinder componentFinder = new ComponentFinder(
+                webApplication,
+                "Structurizr.Examples.Annotations",
+                new StructurizrAnnotationsComponentFinderStrategy(assembly)
+            );
+            componentFinder.FindComponents();
+            model.AddImplicitRelationships();
+
+            ViewSet views = workspace.Views;
+            SystemContextView contextView = views.CreateSystemContextView(softwareSystem, "SystemContext", "An example of a System Context diagram.");
+            contextView.AddAllElements();
+
+            ContainerView containerView = views.CreateContainerView(softwareSystem, "Containers", "The container diagram from my software system.");
+            containerView.AddAllElements();
+
+            ComponentView componentView = views.CreateComponentView(webApplication, "Components", "The component diagram for the web application.");
+            componentView.AddAllElements();
+
+            Styles styles = views.Configuration.Styles;
+            styles.Add(new ElementStyle(Tags.Element) { Color = "#ffffff" });
+            styles.Add(new ElementStyle(Tags.SoftwareSystem) { Background = "#1168bd" });
+            styles.Add(new ElementStyle(Tags.Container) { Background = "#438dd5" });
+            styles.Add(new ElementStyle(Tags.Component) { Background = "#85bbf0", Color = "#000000" });
+            styles.Add(new ElementStyle(Tags.Person) { Background = "#08427b", Shape = Shape.Person });
+            styles.Add(new ElementStyle(DATABASE_TAG) { Shape = Shape.Cylinder });
+
+            StructurizrClient structurizrClient = new StructurizrClient(ApiKey, ApiSecret);
+            structurizrClient.PutWorkspace(WorkspaceId, workspace);
+        }
+    }
+}

--- a/Structurizr.Cecil.Examples/StructurizrAnnotations.cs
+++ b/Structurizr.Cecil.Examples/StructurizrAnnotations.cs
@@ -7,9 +7,16 @@ using Structurizr.Api;
 
 namespace Structurizr.Examples
 {
+
+    /// <summary>
+    /// A small example that illustrates how to use the Structurizr annotations
+    /// in conjunction with the StructurizrAnnotationsComponentFinderStrategy.
+    /// 
+    /// The live workspace is available to view at https://structurizr.com/share/38339
+    /// </summary>
     public class StructurizrAnnotations
     {
-        private const string DATABASE_TAG = "Database";
+        private const string DatabaseTag = "Database";
 
         private const long WorkspaceId = 38339;
         private const string ApiKey = "key";
@@ -25,7 +32,7 @@ namespace Structurizr.Examples
 
             Container webApplication = softwareSystem.AddContainer("Web Application", "Provides users with information.", "C#");
             Container database = softwareSystem.AddContainer("Database", "Stores information.", "Relational database schema");
-            database.AddTags(DATABASE_TAG);
+            database.AddTags(DatabaseTag);
 
             string assemblyPath = typeof(StructurizrAnnotations).Assembly.Location;
             DefaultAssemblyResolver resolver = new DefaultAssemblyResolver();
@@ -59,7 +66,7 @@ namespace Structurizr.Examples
             styles.Add(new ElementStyle(Tags.Container) { Background = "#438dd5" });
             styles.Add(new ElementStyle(Tags.Component) { Background = "#85bbf0", Color = "#000000" });
             styles.Add(new ElementStyle(Tags.Person) { Background = "#08427b", Shape = Shape.Person });
-            styles.Add(new ElementStyle(DATABASE_TAG) { Shape = Shape.Cylinder });
+            styles.Add(new ElementStyle(DatabaseTag) { Shape = Shape.Cylinder });
 
             StructurizrClient structurizrClient = new StructurizrClient(ApiKey, ApiSecret);
             structurizrClient.PutWorkspace(WorkspaceId, workspace);

--- a/Structurizr.Cecil/Analysis/CecilTypeRepository.cs
+++ b/Structurizr.Cecil/Analysis/CecilTypeRepository.cs
@@ -151,8 +151,8 @@ namespace Structurizr.Analysis
         /// <inheritdoc />
         public string FindVisibility(string typeName)
         {
-            TypeDefinition type = _types[typeName];
-            if (type != null)
+            TypeDefinition type;
+            if (_types.TryGetValue(typeName, out type) && type != null)
             {
                 if (type.IsPublic)
                 {
@@ -171,8 +171,8 @@ namespace Structurizr.Analysis
         /// <inheritdoc />
         public string FindCategory(string typeName)
         {
-            TypeDefinition type = _types[typeName];
-            if (type != null)
+            TypeDefinition type;
+            if (_types.TryGetValue(typeName, out type) && type != null)
             {
                 if (type.IsAbstract)
                 {

--- a/Structurizr.Cecil/Analysis/CecilTypeRepository.cs
+++ b/Structurizr.Cecil/Analysis/CecilTypeRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -66,7 +67,14 @@ namespace Structurizr.Analysis
         /// <inheritdoc />
         public TypeDefinition GetType(string typeName)
         {
-            return _types.Values.SingleOrDefault(t => typeName == t.FullName);
+            Func<TypeDefinition, bool> predicate;
+            var split = typeName.Split(new[] { ", " }, 2, StringSplitOptions.RemoveEmptyEntries);
+            if (split.Length == 2)
+                predicate = t => t.FullName == split[0] && t.Module.Assembly.FullName == split[1];
+            else
+                predicate = t => t.FullName == typeName;
+
+            return _types.Values.SingleOrDefault(predicate);
         }
 
         /// <inheritdoc />

--- a/Structurizr.Cecil/Analysis/CecilTypeRepository.cs
+++ b/Structurizr.Cecil/Analysis/CecilTypeRepository.cs
@@ -64,6 +64,12 @@ namespace Structurizr.Analysis
         }
 
         /// <inheritdoc />
+        public TypeDefinition GetType(string typeName)
+        {
+            return _types.Values.SingleOrDefault(t => typeName == t.FullName);
+        }
+
+        /// <inheritdoc />
         public IEnumerable<string> GetReferencedTypes(string typeName)
         {
             // use the cached version if possible

--- a/Structurizr.Cecil/Analysis/ITypeRepository.cs
+++ b/Structurizr.Cecil/Analysis/ITypeRepository.cs
@@ -8,6 +8,7 @@ namespace Structurizr.Analysis
     {
         string Namespace { get; }
         IEnumerable<TypeDefinition> GetAllTypes();
+        TypeDefinition GetType(string typeName);
         IEnumerable<string> GetReferencedTypes(string type);
 
         string FindCategory(string typeName);

--- a/Structurizr.Cecil/Analysis/StructurizrAnnotationsComponentFinderStrategy.cs
+++ b/Structurizr.Cecil/Analysis/StructurizrAnnotationsComponentFinderStrategy.cs
@@ -37,15 +37,29 @@ namespace Structurizr.Analysis
             {
                 if (!type.HasCustomAttributes) continue;
                 var componentAttribute = type.CustomAttributes.OfType<ComponentAttribute>().FirstOrDefault();
-                if (componentAttribute == null) continue;
+                if (componentAttribute != null)
+                {
+                    Component component = ComponentFinder.Container.AddComponent(
+                        type.Name,
+                        type.GetAssemblyQualifiedName(),
+                        componentAttribute.Description,
+                        componentAttribute.Technology
+                    );
+                    _componentsFound.Add(component);
+                    continue; // CodeElementAttribute on a type already decorated with ComponentAttribute is ignored
+                }
 
-                Component component = ComponentFinder.Container.AddComponent(
-                    type.Name,
-                    type.GetAssemblyQualifiedName(),
-                    componentAttribute.Description,
-                    componentAttribute.Technology
-                );
-                _componentsFound.Add(component);
+                var codeElementAttribute = type.CustomAttributes.OfType<CodeElementAttribute>().FirstOrDefault();
+                if (codeElementAttribute != null)
+                {
+                    Component component =
+                        ComponentFinder.Container.GetComponentOfType(codeElementAttribute.ComponentName)
+                        ?? ComponentFinder.Container.GetComponentWithName(codeElementAttribute.ComponentName);
+                    if (component == null) continue;
+
+                    CodeElement codeElement = component.AddSupportingType(type.GetAssemblyQualifiedName());
+                    codeElement.Description = codeElementAttribute.Description;
+                }
             }
 
             return _componentsFound;

--- a/Structurizr.Cecil/Analysis/StructurizrAnnotationsComponentFinderStrategy.cs
+++ b/Structurizr.Cecil/Analysis/StructurizrAnnotationsComponentFinderStrategy.cs
@@ -1,0 +1,244 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Mono.Cecil;
+
+using Structurizr.Annotations;
+using Structurizr.Cecil;
+
+namespace Structurizr.Analysis
+{
+    public class StructurizrAnnotationsComponentFinderStrategy : ComponentFinderStrategy
+    {
+        public ComponentFinder ComponentFinder { get; set; }
+
+        private HashSet<Component> _componentsFound = new HashSet<Component>();
+
+        private AssemblyDefinition _primaryAssembly;
+
+        private ITypeRepository _typeRepository;
+
+        public StructurizrAnnotationsComponentFinderStrategy(AssemblyDefinition assembly)
+        {
+            this._primaryAssembly = assembly;
+        }
+
+        public void BeforeFindComponents()
+        {
+            _typeRepository = new CecilTypeRepository(
+                _primaryAssembly,
+                ComponentFinder.Namespace,
+                ComponentFinder.Exclusions);
+        }
+
+        public IEnumerable<Component> FindComponents()
+        {
+            foreach(TypeDefinition type in _typeRepository.GetAllTypes())
+            {
+                if (!type.HasCustomAttributes) continue;
+                var componentAttribute = type.CustomAttributes.OfType<ComponentAttribute>().FirstOrDefault();
+                if (componentAttribute == null) continue;
+
+                Component component = ComponentFinder.Container.AddComponent(
+                    type.Name,
+                    type.GetAssemblyQualifiedName(),
+                    componentAttribute.Description,
+                    componentAttribute.Technology
+                );
+                _componentsFound.Add(component);
+            }
+
+            return _componentsFound;
+        }
+
+        public void AfterFindComponents()
+        {
+            foreach (Component component in _componentsFound)
+            {
+                foreach (CodeElement codeElement in component.CodeElements)
+                {
+                    codeElement.Visibility = _typeRepository.FindVisibility(codeElement.Type);
+                    codeElement.Category = _typeRepository.FindCategory(codeElement.Type);
+
+                    FindUsesComponentAnnotations(component, codeElement.Type);
+                    FindUsesContainerAnnotations(component, codeElement.Type);
+                    FindUsedBySoftwareSystemAnnotations(component, codeElement.Type);
+
+                    FindUsedByPersonAnnotations(component, codeElement.Type);
+                    FindUsedBySoftwareSystemAnnotations(component, codeElement.Type);
+                    FindUsedBySoftwareSystemAnnotations(component, codeElement.Type);
+                }
+            }
+        }
+
+        private void FindUsesComponentAnnotations(Component component, string typeName)
+        {
+            TypeDefinition type = _typeRepository.GetType(typeName);
+            if (type == null)
+            {
+                // todo: logging
+                return;
+            }
+
+            foreach (FieldDefinition field in type.Fields)
+            {
+                if (!field.HasCustomAttributes) continue;
+                var annotation = field.CustomAttributes.OfType<UsesComponentAttribute>().SingleOrDefault();
+                if (annotation == null) continue;
+
+                string destinationTypeName = field.FieldType.FullName;
+                Component destination = ComponentFinder.Container.GetComponentOfType(destinationTypeName);
+                if (destination != null)
+                {
+                    foreach (Relationship relationship in component.Relationships.Where(r => r.Destination == destination))
+                    {
+                        relationship.Description = annotation.Description;
+                        relationship.Technology = annotation.Technology;
+                    }
+                }
+                else
+                {
+                    // todo: logging
+                }
+            }
+        }
+
+        private void FindUsesContainerAnnotations(Component component, string typeName)
+        {
+            TypeDefinition type = _typeRepository.GetType(typeName);
+            if (type == null)
+            {
+                // todo: logging
+                return;
+            }
+            if (!type.HasCustomAttributes) return;
+
+            var annotations = type.CustomAttributes.OfType<UsesContainerAttribute>().ToList();
+            foreach(UsesContainerAttribute annotation in annotations)
+            {
+                Container container = FindContainerByNameOrId(component, annotation.ContainerName);
+                if (container != null)
+                {
+                    component.Uses(container, annotation.Description, annotation.Technology);
+                }
+                else
+                {
+                    // todo: logging
+                }
+            }
+        }
+
+        private void FindUsesSoftwareSystemAnnotations(Component component, string typeName)
+        {
+            TypeDefinition type = _typeRepository.GetType(typeName);
+            if (type == null)
+            {
+                // todo: logging
+                return;
+            }
+            if (!type.HasCustomAttributes) return;
+
+            var annotations = type.CustomAttributes.OfType<UsesSoftwareSystemAttribute>().ToList();
+            foreach(UsesSoftwareSystemAttribute annotation in annotations)
+            {
+                SoftwareSystem system = component.Model.GetSoftwareSystemWithName(annotation.SoftwareSystemName);
+                if (system != null)
+                {
+                    component.Uses(system, annotation.Description, annotation.Technology);
+                }
+                else
+                {
+                    // todo: logging
+                }
+            }
+        }
+
+        private void FindUsedByContainerAnnotations(Component component, string typeName)
+        {
+            TypeDefinition type = _typeRepository.GetType(typeName);
+            if (type == null)
+            {
+                // todo: logging
+                return;
+            }
+            if (!type.HasCustomAttributes) return;
+
+            var annotations = type.CustomAttributes.OfType<UsedByContainerAttribute>().ToList();
+            foreach(UsedByContainerAttribute annotation in annotations)
+            {
+                Container container = FindContainerByNameOrId(component, annotation.ContainerName);
+                if (container != null)
+                {
+                    container.Uses(component, annotation.Description, annotation.Technology);
+                }
+                else
+                {
+                    // todo: logging
+                }
+            }
+        }
+
+        private void FindUsedByPersonAnnotations(Component component, string typeName)
+        {
+            TypeDefinition type = _typeRepository.GetType(typeName);
+            if (type == null)
+            {
+                // todo: logging
+                return;
+            }
+            if (!type.HasCustomAttributes) return;
+
+            var annotations = type.CustomAttributes.OfType<UsedByPersonAttribute>().ToList();
+            foreach(UsedByPersonAttribute annotation in annotations)
+            {
+                Person person = component.Model.GetPersonWithName(annotation.PersonName);
+                if (person != null)
+                {
+                    person.Uses(component, annotation.Description, annotation.Technology);
+                }
+                else
+                {
+                    // todo: logging
+                }
+            }
+        }
+
+        private void FindUsedBySoftwareSystemAnnotations(Component component, string typeName)
+        {
+            TypeDefinition type = _typeRepository.GetType(typeName);
+            if (type == null)
+            {
+                // todo: logging
+                return;
+            }
+            if (!type.HasCustomAttributes) return;
+
+            var annotations = type.CustomAttributes.OfType<UsedBySoftwareSystemAttribute>().ToList();
+            foreach(UsedBySoftwareSystemAttribute annotation in annotations)
+            {
+                SoftwareSystem system = component.Model.GetSoftwareSystemWithName(annotation.SoftwareSystemName);
+                if (system != null)
+                {
+                    system.Uses(component, annotation.Description, annotation.Technology);
+                }
+                else
+                {
+                    // todo: logging
+                }
+            }
+        }
+
+        private Container FindContainerByNameOrId(Component component, string name)
+        {
+            // assume that the container resides in the same software system
+            Container container = component.Container.SoftwareSystem.GetContainerWithName(name);
+            if (container == null)
+            {
+                // perhaps it's an element ID?
+                container = component.Model.GetElement(name) as Container;
+            }
+
+            return container;
+        }
+    }
+}

--- a/Structurizr.Cecil/Analysis/SupportingTypes/ReferencedTypesSupportingTypesStrategy.cs
+++ b/Structurizr.Cecil/Analysis/SupportingTypes/ReferencedTypesSupportingTypesStrategy.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace Structurizr.Analysis.SupportingTypes
 {
-    class ReferencedTypesSupportingTypesStrategy : SupportingTypesStrategy
+    public class ReferencedTypesSupportingTypesStrategy : SupportingTypesStrategy
     {
         private bool _includeIndirectlyReferencedTypes;
 

--- a/Structurizr.Cecil/Structurizr.Cecil.csproj
+++ b/Structurizr.Cecil/Structurizr.Cecil.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Structurizr.Annotations\Structurizr.Annotations.csproj" />
     <ProjectReference Include="..\Structurizr.Core\Structurizr.Core.csproj" />
   </ItemGroup>
 

--- a/Structurizr.Cecil/Util/CustomAttributeExtensions.cs
+++ b/Structurizr.Cecil/Util/CustomAttributeExtensions.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Mono.Cecil;
+
+namespace Structurizr.Cecil.Util
+{
+    static class CustomAttributeExtensions
+    {
+        public static IEnumerable<TAttribute> ResolvableAttributes<TAttribute>(this TypeDefinition klassType)
+            where TAttribute : Attribute
+        {
+            var attributeType = typeof(TAttribute).GetTypeInfo();
+
+            foreach (var customAttribute in klassType.CustomAttributes)
+            {
+                if (!customAttribute.Is<TAttribute>()) continue;
+
+                var arguments = customAttribute.ConstructorArguments.Select(a => a.Value).ToArray();
+
+                var createdAttribute = (TAttribute)Activator.CreateInstance(typeof(TAttribute), arguments);
+                foreach (var attributeProperty in customAttribute.Properties)
+                {
+                    var propertyInfo = attributeType.GetDeclaredProperty(attributeProperty.Name);
+                    propertyInfo.SetValue(createdAttribute, attributeProperty.Argument.Value);
+                }
+
+                yield return createdAttribute;
+            }
+        }
+
+        public static IEnumerable<TAttribute> ResolvableAttributes<TAttribute>(this FieldDefinition field)
+            where TAttribute : Attribute
+        {
+            var attributeType = typeof(TAttribute).GetTypeInfo();
+
+            foreach (var customAttribute in field.CustomAttributes)
+            {
+                if (!customAttribute.Is<TAttribute>()) continue;
+
+                var arguments = customAttribute.ConstructorArguments.Select(a => a.Value).ToArray();
+
+                var createdAttribute = (TAttribute)Activator.CreateInstance(typeof(TAttribute), arguments);
+                foreach (var attributeProperty in customAttribute.Properties)
+                {
+                    var propertyInfo = attributeType.GetDeclaredProperty(attributeProperty.Name);
+                    propertyInfo.SetValue(createdAttribute, attributeProperty.Argument.Value);
+                }
+
+                yield return createdAttribute;
+            }
+        }
+
+        public static IEnumerable<TAttribute> ResolvableAttributes<TAttribute>(this PropertyDefinition property)
+            where TAttribute : Attribute
+        {
+            var attributeType = typeof(TAttribute).GetTypeInfo();
+
+            foreach (var customAttribute in property.CustomAttributes)
+            {
+                if (!customAttribute.Is<TAttribute>()) continue;
+
+                var arguments = customAttribute.ConstructorArguments.Select(a => a.Value).ToArray();
+
+                var createdAttribute = (TAttribute)Activator.CreateInstance(typeof(TAttribute), arguments);
+                foreach (var attributeProperty in customAttribute.Properties)
+                {
+                    var propertyInfo = attributeType.GetDeclaredProperty(attributeProperty.Name);
+                    propertyInfo.SetValue(createdAttribute, attributeProperty.Argument.Value);
+                }
+
+                yield return createdAttribute;
+            }
+        }
+
+        public static IEnumerable<TAttribute> ResolvableAttributes<TAttribute>(this ParameterDefinition parameter)
+            where TAttribute : Attribute
+        {
+            var attributeType = typeof(TAttribute).GetTypeInfo();
+
+            foreach (var customAttribute in parameter.CustomAttributes)
+            {
+                if (!customAttribute.Is<TAttribute>()) continue;
+
+                var arguments = customAttribute.ConstructorArguments.Select(a => a.Value).ToArray();
+
+                var createdAttribute = (TAttribute)Activator.CreateInstance(typeof(TAttribute), arguments);
+                foreach (var attributeProperty in customAttribute.Properties)
+                {
+                    var propertyInfo = attributeType.GetDeclaredProperty(attributeProperty.Name);
+                    propertyInfo.SetValue(createdAttribute, attributeProperty.Argument.Value);
+                }
+
+                yield return createdAttribute;
+            }
+        }
+
+        private static bool Is<TAttribute>(this CustomAttribute attribute)
+        {
+            return attribute.AttributeType.FullName == typeof(TAttribute).FullName;
+        }
+    }
+}

--- a/Structurizr.Reflection.Examples/Annotations/EfRepository.cs
+++ b/Structurizr.Reflection.Examples/Annotations/EfRepository.cs
@@ -1,0 +1,14 @@
+using Structurizr.Annotations;
+
+namespace Structurizr.Examples.Annotations
+{
+    [CodeElement(nameof(IRepository), Description = "Implementation")]
+    [UsesContainer("Database", Description = "Reads from", Technology = "Entity Framework")]
+    class EfRepository : IRepository
+    {
+        public string GetData(long id)
+        {
+            return "...";
+        }
+    }
+}

--- a/Structurizr.Reflection.Examples/Annotations/HtmlController.cs
+++ b/Structurizr.Reflection.Examples/Annotations/HtmlController.cs
@@ -1,0 +1,12 @@
+using Structurizr.Annotations;
+
+namespace Structurizr.Examples.Annotations
+{
+    [Component(Description = "Serves HTML pages to users.", Technology = "ASP.NET MVC")]
+    [UsedByPerson("User", Description = "Uses", Technology = "HTTPS")]
+    class HtmlController
+    {
+        [UsesComponent("Gets data using")]
+        private IRepository repository = new EfRepository();
+    }
+}

--- a/Structurizr.Reflection.Examples/Annotations/IRepository.cs
+++ b/Structurizr.Reflection.Examples/Annotations/IRepository.cs
@@ -1,0 +1,10 @@
+using Structurizr.Annotations;
+
+namespace Structurizr.Examples.Annotations
+{
+    [Component(Description = "Provides access to data stored in the database.", Technology = "C#")]
+    public interface IRepository
+    {
+        string GetData(long id);
+    }
+}

--- a/Structurizr.Reflection.Examples/Structurizr.Reflection.Examples.csproj
+++ b/Structurizr.Reflection.Examples/Structurizr.Reflection.Examples.csproj
@@ -10,4 +10,7 @@
     <ProjectReference Include="..\Structurizr.Core\Structurizr.Core.csproj" />
     <ProjectReference Include="..\Structurizr.Reflection\Structurizr.Reflection.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Runtime" />
+  </ItemGroup>
 </Project>

--- a/Structurizr.Reflection.Examples/StructurizrAnnotations.cs
+++ b/Structurizr.Reflection.Examples/StructurizrAnnotations.cs
@@ -1,0 +1,63 @@
+using Structurizr.Analysis;
+using Structurizr.Api;
+
+namespace Structurizr.Examples
+{
+
+    /// <summary>
+    /// A small example that illustrates how to use the Structurizr annotations
+    /// in conjunction with the StructurizrAnnotationsComponentFinderStrategy.
+    /// 
+    /// The live workspace is available to view at https://structurizr.com/share/38341
+    /// </summary>
+    public class StructurizrAnnotations
+    {
+        private const string DatabaseTag = "Database";
+
+        private const long WorkspaceId = 38341;
+        private const string ApiKey = "key";
+        private const string ApiSecret = "secret";
+
+        static void Main()
+        {
+            Workspace workspace = new Workspace("Structurizr for .NET Annotations", "This is a model of my software system.");
+            Model model = workspace.Model;
+
+            Person user = model.AddPerson("User", "A user of my software system.");
+            SoftwareSystem softwareSystem = model.AddSoftwareSystem("Software System", "My software system.");
+
+            Container webApplication = softwareSystem.AddContainer("Web Application", "Provides users with information.", "C#");
+            Container database = softwareSystem.AddContainer("Database", "Stores information.", "Relational database schema");
+            database.AddTags(DatabaseTag);
+
+            ComponentFinder componentFinder = new ComponentFinder(
+                webApplication,
+                "Structurizr.Examples.Annotations",
+                new StructurizrAnnotationsComponentFinderStrategy()
+            );
+            componentFinder.FindComponents();
+            model.AddImplicitRelationships();
+
+            ViewSet views = workspace.Views;
+            SystemContextView contextView = views.CreateSystemContextView(softwareSystem, "SystemContext", "An example of a System Context diagram.");
+            contextView.AddAllElements();
+
+            ContainerView containerView = views.CreateContainerView(softwareSystem, "Containers", "The container diagram from my software system.");
+            containerView.AddAllElements();
+
+            ComponentView componentView = views.CreateComponentView(webApplication, "Components", "The component diagram for the web application.");
+            componentView.AddAllElements();
+
+            Styles styles = views.Configuration.Styles;
+            styles.Add(new ElementStyle(Tags.Element) { Color = "#ffffff" });
+            styles.Add(new ElementStyle(Tags.SoftwareSystem) { Background = "#1168bd" });
+            styles.Add(new ElementStyle(Tags.Container) { Background = "#438dd5" });
+            styles.Add(new ElementStyle(Tags.Component) { Background = "#85bbf0", Color = "#000000" });
+            styles.Add(new ElementStyle(Tags.Person) { Background = "#08427b", Shape = Shape.Person });
+            styles.Add(new ElementStyle(DatabaseTag) { Shape = Shape.Cylinder });
+
+            StructurizrClient structurizrClient = new StructurizrClient(ApiKey, ApiSecret);
+            structurizrClient.PutWorkspace(WorkspaceId, workspace);
+        }
+    }
+}

--- a/Structurizr.Reflection/Analysis/ITypeRepository.cs
+++ b/Structurizr.Reflection/Analysis/ITypeRepository.cs
@@ -9,6 +9,7 @@ namespace Structurizr.Analysis
 
         string Namespace { get; }
         IEnumerable<Type> GetAllTypes();
+        Type GetType(string type);
         IEnumerable<string> GetReferencedTypes(string type);
 
         string FindCategory(string typeName);

--- a/Structurizr.Reflection/Analysis/ReflectionTypeRepository.cs
+++ b/Structurizr.Reflection/Analysis/ReflectionTypeRepository.cs
@@ -54,6 +54,18 @@ namespace Structurizr.Analysis
             return _types.Values;
         }
 
+        public Type GetType(string typeName)
+        {
+            Func<Type, bool> predicate;
+            var split = typeName.Split(new[] { ", " }, 2, StringSplitOptions.RemoveEmptyEntries);
+            if (split.Length == 2)
+                predicate = t => t.FullName == split[0] && t.Module.Assembly.FullName == split[1];
+            else
+                predicate = t => t.FullName == typeName;
+
+            return _types.Values.SingleOrDefault(predicate);
+        }
+
         public IEnumerable<string> GetReferencedTypes(string typeName)
         {
             // use the cached version if possible

--- a/Structurizr.Reflection/Analysis/StructurizrAnnotationsComponentFinderStrategy.cs
+++ b/Structurizr.Reflection/Analysis/StructurizrAnnotationsComponentFinderStrategy.cs
@@ -1,0 +1,319 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using Structurizr.Annotations;
+
+namespace Structurizr.Analysis
+{
+    public class StructurizrAnnotationsComponentFinderStrategy : ComponentFinderStrategy
+    {
+        public ComponentFinder ComponentFinder { get; set; }
+
+        private HashSet<Component> _componentsFound = new HashSet<Component>();
+
+        private ITypeRepository _typeRepository;
+        private List<SupportingTypesStrategy> _supportingTypesStrategies = new List<SupportingTypesStrategy>();
+
+        public void BeforeFindComponents()
+        {
+            _typeRepository = new ReflectionTypeRepository(ComponentFinder.Namespace, ComponentFinder.Exclusions);
+            foreach (SupportingTypesStrategy strategy in _supportingTypesStrategies)
+            {
+                strategy.TypeRepository = _typeRepository;
+            }
+        }
+
+        public IEnumerable<Component> FindComponents()
+        {
+            List<Type> types = _typeRepository.GetAllTypes().ToList();
+
+            foreach (Type type in types)
+            {
+                ComponentAttribute componentAttribute = type.GetCustomAttribute<ComponentAttribute>();
+                if (componentAttribute == null) continue;
+
+                Component component = ComponentFinder.Container.AddComponent(
+                    type.Name,
+                    type,
+                    componentAttribute.Description,
+                    componentAttribute.Technology);
+                _componentsFound.Add(component);
+            }
+
+            // Look for code elements after finding all the components
+            foreach (Type type in types)
+            {
+                CodeElementAttribute codeElementAttribute = type.GetCustomAttribute<CodeElementAttribute>();
+                if (codeElementAttribute == null) continue;
+
+                Component component =
+                    ComponentFinder.Container.GetComponentOfType(codeElementAttribute.ComponentName)
+                    ?? ComponentFinder.Container.GetComponentWithName(codeElementAttribute.ComponentName);
+                if (component != null)
+                {
+                    CodeElement codeElement = component.AddSupportingType(type.AssemblyQualifiedName);
+                    codeElement.Description = codeElementAttribute.Description;
+                }
+                else
+                {
+                    // todo: logging
+                }
+            }
+
+            return _componentsFound;
+        }
+
+        public void AfterFindComponents()
+        {
+            foreach (Component component in _componentsFound)
+            {
+                foreach (SupportingTypesStrategy strategy in _supportingTypesStrategies)
+                {
+                    foreach (string type in strategy.FindSupportingTypes(component))
+                    {
+                        if (ComponentFinder.Container.GetComponentOfType(type) == null)
+                        {
+                            component.AddSupportingType(type);
+                        }
+                    }
+                }
+
+                foreach (CodeElement codeElement in component.CodeElements)
+                {
+                    codeElement.Visibility = _typeRepository.FindVisibility(codeElement.Type);
+                    codeElement.Category = _typeRepository.FindCategory(codeElement.Type);
+
+                    FindUsesComponentAnnotations(component, codeElement.Type);
+                    FindUsesContainerAnnotations(component, codeElement.Type);
+                    FindUsesSoftwareSystemAnnotations(component, codeElement.Type);
+
+                    FindUsedByPersonAnnotations(component, codeElement.Type);
+                    FindUsedByContainerAnnotations(component, codeElement.Type);
+                    FindUsedBySoftwareSystemAnnotations(component, codeElement.Type);
+                }
+            }
+        }
+
+        private void FindUsesComponentAnnotations(Component component, string typeName)
+        {
+            Type type = _typeRepository.GetType(typeName);
+            if (type == null)
+            {
+                // todo: logging
+                return;
+            }
+
+            foreach (FieldInfo field in type.GetRuntimeFields())
+            {
+                var annotation = field.GetCustomAttribute<UsesComponentAttribute>();
+                if (annotation == null) continue;
+
+                AddUsesComponentRelationship(component, field.FieldType, annotation);
+            }
+
+            foreach (PropertyInfo property in type.GetRuntimeProperties())
+            {
+                var annotation = property.GetCustomAttribute<UsesComponentAttribute>();
+                if (annotation == null) continue;
+
+                AddUsesComponentRelationship(component, property.PropertyType, annotation);
+            }
+
+            foreach (MethodInfo method in type.GetRuntimeMethods())
+            {
+                foreach (var parameter in method.GetParameters())
+                {
+                    var annotation = parameter.GetCustomAttribute<UsesComponentAttribute>();
+                    if (annotation == null) continue;
+
+                    AddUsesComponentRelationship(component, parameter.ParameterType, annotation);
+                }
+            }
+        }
+
+        private void AddUsesComponentRelationship(
+            Component component,
+            Type destinationType,
+            UsesComponentAttribute annotation)
+        {
+            if (annotation == null)
+            {
+                // todo: logging
+                return;
+            }
+
+            Component destination = ComponentFinder.Container.GetComponentOfType(destinationType.AssemblyQualifiedName);
+            if (destination != null)
+            {
+                IList<Relationship> relationships = component.Relationships
+                    .Where(r => r.Destination.Equals(destination))
+                    .ToList();
+                if (relationships.Count > 0)
+                {
+                    foreach (Relationship relationship in relationships)
+                    {
+                        relationship.Description = annotation.Description;
+                        relationship.Technology = annotation.Technology;
+                    }
+                }
+                else
+                {
+                    // Relationship doesn't already exist, so add it
+                    component.Uses(destination, annotation.Description, annotation.Technology);
+                }
+            }
+            else
+            {
+                // todo: logging
+            }
+        }
+
+        private void FindUsesContainerAnnotations(Component component, string typeName)
+        {
+            Type type = _typeRepository.GetType(typeName);
+            if (type == null)
+            {
+                // todo: logging
+                return;
+            }
+
+            var annotations = type.GetCustomAttributes<UsesContainerAttribute>();
+            foreach(UsesContainerAttribute annotation in annotations)
+            {
+                Container container = FindContainerByNameOrId(component, annotation.ContainerName);
+                if (container != null)
+                {
+                    component.Uses(container, annotation.Description, annotation.Technology);
+                }
+                else
+                {
+                    // todo: logging
+                }
+            }
+        }
+
+        private void FindUsesSoftwareSystemAnnotations(Component component, string typeName)
+        {
+            var type = _typeRepository.GetType(typeName);
+            if (type == null)
+            {
+                // todo: logging
+                return;
+            }
+
+            var annotations = type.GetCustomAttributes<UsesSoftwareSystemAttribute>();
+            foreach(UsesSoftwareSystemAttribute annotation in annotations)
+            {
+                SoftwareSystem system = component.Model.GetSoftwareSystemWithName(annotation.SoftwareSystemName);
+                if (system != null)
+                {
+                    component.Uses(system, annotation.Description, annotation.Technology);
+                }
+                else
+                {
+                    // todo: logging
+                }
+            }
+        }
+
+        private void FindUsedByPersonAnnotations(Component component, string typeName)
+        {
+            Type type = _typeRepository.GetType(typeName);
+            if (type == null)
+            {
+                // todo: logging
+                return;
+            }
+
+            var annotations = type.GetCustomAttributes<UsedByPersonAttribute>();
+            foreach (UsedByPersonAttribute annotation in annotations)
+            {
+                Person person = component.Model.GetPersonWithName(annotation.PersonName);
+                if (person != null)
+                {
+                    person.Uses(component, annotation.Description, annotation.Technology);
+                }
+                else
+                {
+                    // todo: logging
+                }
+            }
+        }
+
+        private void FindUsedByContainerAnnotations(Component component, string typeName)
+        {
+            Type type = _typeRepository.GetType(typeName);
+            if (type == null)
+            {
+                // todo: logging
+                return;
+            }
+
+            var annotations = type.GetCustomAttributes<UsedByContainerAttribute>();
+            foreach (UsedByContainerAttribute annotation in annotations)
+            {
+                Container container = FindContainerByNameOrId(component, annotation.ContainerName);
+                if (container != null)
+                {
+                    container.Uses(component, annotation.Description, annotation.Technology);
+                }
+                else
+                {
+                    // todo: logging
+                }
+            }
+        }
+
+        private void FindUsedBySoftwareSystemAnnotations(Component component, string typeName)
+        {
+            Type type = _typeRepository.GetType(typeName);
+            if (type == null)
+            {
+                // todo: logging
+                return;
+            }
+
+            var annotations = type.GetCustomAttributes<UsedBySoftwareSystemAttribute>();
+            foreach (UsedBySoftwareSystemAttribute annotation in annotations)
+            {
+                SoftwareSystem system = component.Model.GetSoftwareSystemWithName(annotation.SoftwareSystemName);
+                if (system != null)
+                {
+                    system.Uses(component, annotation.Description, annotation.Technology);
+                }
+                else
+                {
+                    // todo: logging
+                }
+            }
+        }
+
+        private Container FindContainerByNameOrId(Component component, string name)
+        {
+            // assume that the container resides in the same software system
+            Container container = component.Container.SoftwareSystem.GetContainerWithName(name);
+            if (container == null)
+            {
+                // perhaps it's an element ID?
+                container = component.Model.GetElement(name) as Container;
+            }
+
+            return container;
+        }
+
+        /// <summary>
+        /// Adds a SupportingTypeStrategy.
+        /// </summary>
+        /// <param name="strategy">A SupportingTypesStrategy object</param>
+        public void AddSupportingTypesStrategy(SupportingTypesStrategy strategy)
+        {
+            if (strategy != null)
+            {
+                _supportingTypesStrategies.Add(strategy);
+                strategy.TypeRepository = _typeRepository;
+            }
+        }
+    }
+}

--- a/Structurizr.Reflection/Structurizr.Reflection.csproj
+++ b/Structurizr.Reflection/Structurizr.Reflection.csproj
@@ -20,6 +20,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Reference Include="System.Runtime" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Structurizr.Core\Structurizr.Core.csproj" />
   </ItemGroup>
 

--- a/Structurizr.Reflection/Structurizr.Reflection.csproj
+++ b/Structurizr.Reflection/Structurizr.Reflection.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Structurizr.Annotations\Structurizr.Annotations.csproj" />
     <ProjectReference Include="..\Structurizr.Core\Structurizr.Core.csproj" />
   </ItemGroup>
 

--- a/Structurizr.sln
+++ b/Structurizr.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26430.15
@@ -41,10 +41,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Structurizr.Reflection.Exam
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Structurizr.Cecil", "Structurizr.Cecil\Structurizr.Cecil.csproj", "{F7E8ECD8-6C01-4A35-A270-D78576C38694}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Structurizr.Annotations", "Structurizr.Annotations\Structurizr.Annotations.csproj", "{D56FE441-85D8-40D7-928E-1A78C88C80F5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2F8E45CF-19B0-4B49-B7C7-5A3F25A993BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -75,6 +81,18 @@ Global
 		{F7E8ECD8-6C01-4A35-A270-D78576C38694}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F7E8ECD8-6C01-4A35-A270-D78576C38694}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F7E8ECD8-6C01-4A35-A270-D78576C38694}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Debug|x64.ActiveCfg = Debug|x64
+		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Debug|x64.Build.0 = Debug|x64
+		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Debug|x86.ActiveCfg = Debug|x86
+		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Debug|x86.Build.0 = Debug|x86
+		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Release|x64.ActiveCfg = Release|x64
+		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Release|x64.Build.0 = Release|x64
+		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Release|x86.ActiveCfg = Release|x86
+		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Structurizr.sln
+++ b/Structurizr.sln
@@ -1,18 +1,12 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.15
+VisualStudioVersion = 15.0.27130.2027
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{4ED0E8DB-8A5B-4DF0-9CB1-995D97A04B88}"
 	ProjectSection(SolutionItems) = preProject
 		docs\api-client.md = docs\api-client.md
 		docs\binaries.md = docs\binaries.md
 		docs\client-side-encryption.md = docs\client-side-encryption.md
-		docs\documentation.md = docs\documentation.md
-		docs\getting-started.md = docs\getting-started.md
-		README.md = README.md
-		docs\styling-elements.md = docs\styling-elements.md
-		docs\styling-relationships.md = docs\styling-relationships.md
 		docs\component-diagram.md = docs\component-diagram.md
 		docs\container-diagram.md = docs\container-diagram.md
 		docs\corporate-branding.md = docs\corporate-branding.md
@@ -20,10 +14,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{4ED0E8DB-8
 		docs\documentation-arc42.md = docs\documentation-arc42.md
 		docs\documentation-structurizr.md = docs\documentation-structurizr.md
 		docs\documentation-viewpoints-and-perspectives.md = docs\documentation-viewpoints-and-perspectives.md
+		docs\documentation.md = docs\documentation.md
 		docs\dynamic-diagram.md = docs\dynamic-diagram.md
 		docs\enterprise-context-diagram.md = docs\enterprise-context-diagram.md
 		docs\filtered-views.md = docs\filtered-views.md
+		docs\getting-started.md = docs\getting-started.md
 		docs\plantuml.md = docs\plantuml.md
+		README.md = README.md
+		docs\styling-elements.md = docs\styling-elements.md
+		docs\styling-relationships.md = docs\styling-relationships.md
 		docs\system-context-diagram.md = docs\system-context-diagram.md
 	EndProjectSection
 EndProject
@@ -33,68 +32,141 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Structurizr.Core.Tests", "S
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Structurizr.Examples", "Structurizr.Examples\Structurizr.Examples.csproj", "{9BE0761B-F666-4691-9CF7-15CF6E911E17}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Structurizr.Reflection", "Structurizr.Reflection\Structurizr.Reflection.csproj", "{05E515A6-209B-4771-8C6C-3A50646DF1F9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Structurizr.Reflection", "Structurizr.Reflection\Structurizr.Reflection.csproj", "{05E515A6-209B-4771-8C6C-3A50646DF1F9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Structurizr.Roslyn", "Structurizr.Roslyn\Structurizr.Roslyn.csproj", "{B8276441-7DC2-4229-AEAF-CB6598D7DC73}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Structurizr.Roslyn", "Structurizr.Roslyn\Structurizr.Roslyn.csproj", "{B8276441-7DC2-4229-AEAF-CB6598D7DC73}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Structurizr.Reflection.Examples", "Structurizr.Reflection.Examples\Structurizr.Reflection.Examples.csproj", "{7608B23C-2ACA-4C00-9186-F304137FABB9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Structurizr.Reflection.Examples", "Structurizr.Reflection.Examples\Structurizr.Reflection.Examples.csproj", "{7608B23C-2ACA-4C00-9186-F304137FABB9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Structurizr.Cecil", "Structurizr.Cecil\Structurizr.Cecil.csproj", "{F7E8ECD8-6C01-4A35-A270-D78576C38694}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Structurizr.Cecil", "Structurizr.Cecil\Structurizr.Cecil.csproj", "{F7E8ECD8-6C01-4A35-A270-D78576C38694}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Structurizr.Annotations", "Structurizr.Annotations\Structurizr.Annotations.csproj", "{D56FE441-85D8-40D7-928E-1A78C88C80F5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Structurizr.Annotations", "Structurizr.Annotations\Structurizr.Annotations.csproj", "{D56FE441-85D8-40D7-928E-1A78C88C80F5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Structurizr.Cecil.Examples", "Structurizr.Cecil.Examples\Structurizr.Cecil.Examples.csproj", "{F4C524E3-93A3-48F7-8D46-69FEB202D1E7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2F8E45CF-19B0-4B49-B7C7-5A3F25A993BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2F8E45CF-19B0-4B49-B7C7-5A3F25A993BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F8E45CF-19B0-4B49-B7C7-5A3F25A993BD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2F8E45CF-19B0-4B49-B7C7-5A3F25A993BD}.Debug|x64.Build.0 = Debug|Any CPU
+		{2F8E45CF-19B0-4B49-B7C7-5A3F25A993BD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2F8E45CF-19B0-4B49-B7C7-5A3F25A993BD}.Debug|x86.Build.0 = Debug|Any CPU
 		{2F8E45CF-19B0-4B49-B7C7-5A3F25A993BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2F8E45CF-19B0-4B49-B7C7-5A3F25A993BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F8E45CF-19B0-4B49-B7C7-5A3F25A993BD}.Release|x64.ActiveCfg = Release|Any CPU
+		{2F8E45CF-19B0-4B49-B7C7-5A3F25A993BD}.Release|x64.Build.0 = Release|Any CPU
+		{2F8E45CF-19B0-4B49-B7C7-5A3F25A993BD}.Release|x86.ActiveCfg = Release|Any CPU
+		{2F8E45CF-19B0-4B49-B7C7-5A3F25A993BD}.Release|x86.Build.0 = Release|Any CPU
 		{349666B0-A760-4F3D-9D10-BE5E90C4A5E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{349666B0-A760-4F3D-9D10-BE5E90C4A5E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{349666B0-A760-4F3D-9D10-BE5E90C4A5E7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{349666B0-A760-4F3D-9D10-BE5E90C4A5E7}.Debug|x64.Build.0 = Debug|Any CPU
+		{349666B0-A760-4F3D-9D10-BE5E90C4A5E7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{349666B0-A760-4F3D-9D10-BE5E90C4A5E7}.Debug|x86.Build.0 = Debug|Any CPU
 		{349666B0-A760-4F3D-9D10-BE5E90C4A5E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{349666B0-A760-4F3D-9D10-BE5E90C4A5E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{349666B0-A760-4F3D-9D10-BE5E90C4A5E7}.Release|x64.ActiveCfg = Release|Any CPU
+		{349666B0-A760-4F3D-9D10-BE5E90C4A5E7}.Release|x64.Build.0 = Release|Any CPU
+		{349666B0-A760-4F3D-9D10-BE5E90C4A5E7}.Release|x86.ActiveCfg = Release|Any CPU
+		{349666B0-A760-4F3D-9D10-BE5E90C4A5E7}.Release|x86.Build.0 = Release|Any CPU
 		{9BE0761B-F666-4691-9CF7-15CF6E911E17}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9BE0761B-F666-4691-9CF7-15CF6E911E17}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9BE0761B-F666-4691-9CF7-15CF6E911E17}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9BE0761B-F666-4691-9CF7-15CF6E911E17}.Debug|x64.Build.0 = Debug|Any CPU
+		{9BE0761B-F666-4691-9CF7-15CF6E911E17}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9BE0761B-F666-4691-9CF7-15CF6E911E17}.Debug|x86.Build.0 = Debug|Any CPU
 		{9BE0761B-F666-4691-9CF7-15CF6E911E17}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9BE0761B-F666-4691-9CF7-15CF6E911E17}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9BE0761B-F666-4691-9CF7-15CF6E911E17}.Release|x64.ActiveCfg = Release|Any CPU
+		{9BE0761B-F666-4691-9CF7-15CF6E911E17}.Release|x64.Build.0 = Release|Any CPU
+		{9BE0761B-F666-4691-9CF7-15CF6E911E17}.Release|x86.ActiveCfg = Release|Any CPU
+		{9BE0761B-F666-4691-9CF7-15CF6E911E17}.Release|x86.Build.0 = Release|Any CPU
 		{05E515A6-209B-4771-8C6C-3A50646DF1F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{05E515A6-209B-4771-8C6C-3A50646DF1F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{05E515A6-209B-4771-8C6C-3A50646DF1F9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{05E515A6-209B-4771-8C6C-3A50646DF1F9}.Debug|x64.Build.0 = Debug|Any CPU
+		{05E515A6-209B-4771-8C6C-3A50646DF1F9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{05E515A6-209B-4771-8C6C-3A50646DF1F9}.Debug|x86.Build.0 = Debug|Any CPU
 		{05E515A6-209B-4771-8C6C-3A50646DF1F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{05E515A6-209B-4771-8C6C-3A50646DF1F9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{05E515A6-209B-4771-8C6C-3A50646DF1F9}.Release|x64.ActiveCfg = Release|Any CPU
+		{05E515A6-209B-4771-8C6C-3A50646DF1F9}.Release|x64.Build.0 = Release|Any CPU
+		{05E515A6-209B-4771-8C6C-3A50646DF1F9}.Release|x86.ActiveCfg = Release|Any CPU
+		{05E515A6-209B-4771-8C6C-3A50646DF1F9}.Release|x86.Build.0 = Release|Any CPU
 		{B8276441-7DC2-4229-AEAF-CB6598D7DC73}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B8276441-7DC2-4229-AEAF-CB6598D7DC73}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8276441-7DC2-4229-AEAF-CB6598D7DC73}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B8276441-7DC2-4229-AEAF-CB6598D7DC73}.Debug|x64.Build.0 = Debug|Any CPU
+		{B8276441-7DC2-4229-AEAF-CB6598D7DC73}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B8276441-7DC2-4229-AEAF-CB6598D7DC73}.Debug|x86.Build.0 = Debug|Any CPU
 		{B8276441-7DC2-4229-AEAF-CB6598D7DC73}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B8276441-7DC2-4229-AEAF-CB6598D7DC73}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8276441-7DC2-4229-AEAF-CB6598D7DC73}.Release|x64.ActiveCfg = Release|Any CPU
+		{B8276441-7DC2-4229-AEAF-CB6598D7DC73}.Release|x64.Build.0 = Release|Any CPU
+		{B8276441-7DC2-4229-AEAF-CB6598D7DC73}.Release|x86.ActiveCfg = Release|Any CPU
+		{B8276441-7DC2-4229-AEAF-CB6598D7DC73}.Release|x86.Build.0 = Release|Any CPU
 		{7608B23C-2ACA-4C00-9186-F304137FABB9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7608B23C-2ACA-4C00-9186-F304137FABB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7608B23C-2ACA-4C00-9186-F304137FABB9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7608B23C-2ACA-4C00-9186-F304137FABB9}.Debug|x64.Build.0 = Debug|Any CPU
+		{7608B23C-2ACA-4C00-9186-F304137FABB9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7608B23C-2ACA-4C00-9186-F304137FABB9}.Debug|x86.Build.0 = Debug|Any CPU
 		{7608B23C-2ACA-4C00-9186-F304137FABB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7608B23C-2ACA-4C00-9186-F304137FABB9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7608B23C-2ACA-4C00-9186-F304137FABB9}.Release|x64.ActiveCfg = Release|Any CPU
+		{7608B23C-2ACA-4C00-9186-F304137FABB9}.Release|x64.Build.0 = Release|Any CPU
+		{7608B23C-2ACA-4C00-9186-F304137FABB9}.Release|x86.ActiveCfg = Release|Any CPU
+		{7608B23C-2ACA-4C00-9186-F304137FABB9}.Release|x86.Build.0 = Release|Any CPU
 		{F7E8ECD8-6C01-4A35-A270-D78576C38694}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F7E8ECD8-6C01-4A35-A270-D78576C38694}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F7E8ECD8-6C01-4A35-A270-D78576C38694}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F7E8ECD8-6C01-4A35-A270-D78576C38694}.Debug|x64.Build.0 = Debug|Any CPU
+		{F7E8ECD8-6C01-4A35-A270-D78576C38694}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F7E8ECD8-6C01-4A35-A270-D78576C38694}.Debug|x86.Build.0 = Debug|Any CPU
 		{F7E8ECD8-6C01-4A35-A270-D78576C38694}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F7E8ECD8-6C01-4A35-A270-D78576C38694}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F7E8ECD8-6C01-4A35-A270-D78576C38694}.Release|x64.ActiveCfg = Release|Any CPU
+		{F7E8ECD8-6C01-4A35-A270-D78576C38694}.Release|x64.Build.0 = Release|Any CPU
+		{F7E8ECD8-6C01-4A35-A270-D78576C38694}.Release|x86.ActiveCfg = Release|Any CPU
+		{F7E8ECD8-6C01-4A35-A270-D78576C38694}.Release|x86.Build.0 = Release|Any CPU
 		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Debug|x64.ActiveCfg = Debug|x64
-		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Debug|x64.Build.0 = Debug|x64
-		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Debug|x86.ActiveCfg = Debug|x86
-		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Debug|x86.Build.0 = Debug|x86
+		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Debug|x64.Build.0 = Debug|Any CPU
+		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Debug|x86.Build.0 = Debug|Any CPU
 		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Release|x64.ActiveCfg = Release|x64
-		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Release|x64.Build.0 = Release|x64
-		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Release|x86.ActiveCfg = Release|x86
-		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Release|x86.Build.0 = Release|x86
+		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Release|x64.ActiveCfg = Release|Any CPU
+		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Release|x64.Build.0 = Release|Any CPU
+		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Release|x86.ActiveCfg = Release|Any CPU
+		{D56FE441-85D8-40D7-928E-1A78C88C80F5}.Release|x86.Build.0 = Release|Any CPU
+		{F4C524E3-93A3-48F7-8D46-69FEB202D1E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F4C524E3-93A3-48F7-8D46-69FEB202D1E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F4C524E3-93A3-48F7-8D46-69FEB202D1E7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F4C524E3-93A3-48F7-8D46-69FEB202D1E7}.Debug|x64.Build.0 = Debug|Any CPU
+		{F4C524E3-93A3-48F7-8D46-69FEB202D1E7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F4C524E3-93A3-48F7-8D46-69FEB202D1E7}.Debug|x86.Build.0 = Debug|Any CPU
+		{F4C524E3-93A3-48F7-8D46-69FEB202D1E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F4C524E3-93A3-48F7-8D46-69FEB202D1E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F4C524E3-93A3-48F7-8D46-69FEB202D1E7}.Release|x64.ActiveCfg = Release|Any CPU
+		{F4C524E3-93A3-48F7-8D46-69FEB202D1E7}.Release|x64.Build.0 = Release|Any CPU
+		{F4C524E3-93A3-48F7-8D46-69FEB202D1E7}.Release|x86.ActiveCfg = Release|Any CPU
+		{F4C524E3-93A3-48F7-8D46-69FEB202D1E7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1C22C0C2-3375-4503-8953-C7E7AF271C25}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
With this PR, we get parity with the Structurizr annotations on Java, and go one further with an additional `CodeElement` annotation for explicitly marking a type as part of a component. `StructurizrAnnotationsComponentFinderStrategy` implementations are provided for both reflection and Cecil based analysis, and examples have been added for each.

This fixes #12.