### PR TITLE
Console logging for annotations strategy; fix for interface categorization

### DIFF
--- a/Structurizr.Cecil.Examples/Structurizr.Cecil.Examples.csproj
+++ b/Structurizr.Cecil.Examples/Structurizr.Cecil.Examples.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net45</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Structurizr.Cecil/Analysis/CecilTypeRepository.cs
+++ b/Structurizr.Cecil/Analysis/CecilTypeRepository.cs
@@ -174,7 +174,12 @@ namespace Structurizr.Analysis
             TypeDefinition type;
             if (_types.TryGetValue(typeName, out type) && type != null)
             {
-                if (type.IsAbstract)
+                if (type.IsInterface)
+                {
+                    // IsAbstract=true for interfaces so we need to check this first!
+                    return "interface";
+                }
+                else if (type.IsAbstract)
                 {
                     if (type.IsSealed)
                     {
@@ -182,10 +187,6 @@ namespace Structurizr.Analysis
                     }
 
                     return "abstract class";
-                }
-                else if (type.IsInterface)
-                {
-                    return "interface";
                 }
                 else if (type.IsEnum)
                 {

--- a/Structurizr.Cecil/Analysis/StructurizrAnnotationsComponentFinderStrategy.cs
+++ b/Structurizr.Cecil/Analysis/StructurizrAnnotationsComponentFinderStrategy.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -76,7 +77,7 @@ namespace Structurizr.Analysis
                     }
                     else
                     {
-                        // todo: logging
+                        Console.WriteLine("Could not find component " + codeElementAttribute.ComponentName + " for type " + type.FullName);
                     }
                 }
             }
@@ -120,7 +121,7 @@ namespace Structurizr.Analysis
             TypeDefinition type = _typeRepository.GetType(typeName);
             if (type == null)
             {
-                // todo: logging
+                Console.WriteLine("Could not find type " + typeName + " for component " + component.Name);
                 return;
             }
 
@@ -162,7 +163,7 @@ namespace Structurizr.Analysis
         {
             if (annotation == null)
             {
-                // todo: logging
+                Console.WriteLine("Missing UsesComponent annotation on " + component.Name);
                 return;
             }
 
@@ -189,7 +190,7 @@ namespace Structurizr.Analysis
             }
             else
             {
-                // todo: logging
+                Console.WriteLine("Could not find component with " + destinationType.FullName + " for component " + component.Name);
             }
         }
 
@@ -198,7 +199,7 @@ namespace Structurizr.Analysis
             TypeDefinition type = _typeRepository.GetType(typeName);
             if (type == null)
             {
-                // todo: logging
+                Console.WriteLine("Could not find type " + typeName + " for component " + component.Name);
                 return;
             }
             if (!type.HasCustomAttributes) return;
@@ -216,7 +217,7 @@ namespace Structurizr.Analysis
                 }
                 else
                 {
-                    // todo: logging
+                    Console.WriteLine("Could not find container " + annotation.ContainerName + " for component " + component.Name);
                 }
             }
         }
@@ -226,7 +227,7 @@ namespace Structurizr.Analysis
             TypeDefinition type = _typeRepository.GetType(typeName);
             if (type == null)
             {
-                // todo: logging
+                Console.WriteLine("Could not find type " + typeName + " for component " + component.Name);
                 return;
             }
             if (!type.HasCustomAttributes) return;
@@ -244,7 +245,7 @@ namespace Structurizr.Analysis
                 }
                 else
                 {
-                    // todo: logging
+                    Console.WriteLine("Could not find software system " + annotation.SoftwareSystemName + " for component " + component.Name);
                 }
             }
         }
@@ -254,7 +255,7 @@ namespace Structurizr.Analysis
             TypeDefinition type = _typeRepository.GetType(typeName);
             if (type == null)
             {
-                // todo: logging
+                Console.WriteLine("Could not find type " + typeName + " for component " + component.Name);
                 return;
             }
             if (!type.HasCustomAttributes) return;
@@ -272,7 +273,7 @@ namespace Structurizr.Analysis
                 }
                 else
                 {
-                    // todo: logging
+                    Console.WriteLine("Could not find container " + annotation.ContainerName + " using component " + component.Name);
                 }
             }
         }
@@ -282,7 +283,7 @@ namespace Structurizr.Analysis
             TypeDefinition type = _typeRepository.GetType(typeName);
             if (type == null)
             {
-                // todo: logging
+                Console.WriteLine("Could not find type " + typeName + " for component " + component.Name);
                 return;
             }
             if (!type.HasCustomAttributes) return;
@@ -300,7 +301,7 @@ namespace Structurizr.Analysis
                 }
                 else
                 {
-                    // todo: logging
+                    Console.WriteLine("Could not find person " + annotation.PersonName + " using component " + component.Name);
                 }
             }
         }
@@ -310,7 +311,7 @@ namespace Structurizr.Analysis
             TypeDefinition type = _typeRepository.GetType(typeName);
             if (type == null)
             {
-                // todo: logging
+                Console.WriteLine("Could not find type " + typeName + " for component " + component.Name);
                 return;
             }
             if (!type.HasCustomAttributes) return;
@@ -325,7 +326,7 @@ namespace Structurizr.Analysis
                 }
                 else
                 {
-                    // todo: logging
+                    Console.WriteLine("Could not find software system " + annotation.SoftwareSystemName + " using component " + component.Name);
                 }
             }
         }

--- a/Structurizr.Reflection.Examples/Structurizr.Reflection.Examples.csproj
+++ b/Structurizr.Reflection.Examples/Structurizr.Reflection.Examples.csproj
@@ -7,6 +7,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Structurizr.Annotations\Structurizr.Annotations.csproj" />
     <ProjectReference Include="..\Structurizr.Core\Structurizr.Core.csproj" />
     <ProjectReference Include="..\Structurizr.Reflection\Structurizr.Reflection.csproj" />
   </ItemGroup>

--- a/Structurizr.Reflection/Analysis/ReflectionTypeRepository.cs
+++ b/Structurizr.Reflection/Analysis/ReflectionTypeRepository.cs
@@ -163,13 +163,18 @@ namespace Structurizr.Analysis
             Type type = _types[typeName];
             if (type != null)
             {
-                if (type.IsAbstract)
+                if (type.IsInterface)
                 {
-                    return "abstract class";
-                }
-                else if (type.IsInterface)
-                {
+                    // IsAbstract=true for interfaces so we need to check this first!
                     return "interface";
+                }
+                else if (type.IsAbstract)
+                {
+                    if (type.IsSealed)
+                    {
+                        return "static class";
+                    }
+                    return "abstract class";
                 }
                 else if (type.IsEnum)
                 {

--- a/Structurizr.Reflection/Analysis/StructurizrAnnotationsComponentFinderStrategy.cs
+++ b/Structurizr.Reflection/Analysis/StructurizrAnnotationsComponentFinderStrategy.cs
@@ -58,7 +58,7 @@ namespace Structurizr.Analysis
                 }
                 else
                 {
-                    // todo: logging
+                    Console.WriteLine("Could not find component " + codeElementAttribute.ComponentName + " for type " + type.FullName);
                 }
             }
 
@@ -101,7 +101,7 @@ namespace Structurizr.Analysis
             Type type = _typeRepository.GetType(typeName);
             if (type == null)
             {
-                // todo: logging
+                Console.WriteLine("Could not find type " + typeName + " for component " + component.Name);
                 return;
             }
 
@@ -140,7 +140,7 @@ namespace Structurizr.Analysis
         {
             if (annotation == null)
             {
-                // todo: logging
+                Console.WriteLine("Missing UsesComponent annotation on " + component.Name);
                 return;
             }
 
@@ -166,7 +166,7 @@ namespace Structurizr.Analysis
             }
             else
             {
-                // todo: logging
+                Console.WriteLine("Could not find component with " + destinationType.FullName + " for component " + component.Name);
             }
         }
 
@@ -175,7 +175,7 @@ namespace Structurizr.Analysis
             Type type = _typeRepository.GetType(typeName);
             if (type == null)
             {
-                // todo: logging
+                Console.WriteLine("Could not find type " + typeName + " for component " + component.Name);
                 return;
             }
 
@@ -189,7 +189,7 @@ namespace Structurizr.Analysis
                 }
                 else
                 {
-                    // todo: logging
+                    Console.WriteLine("Could not find container " + annotation.ContainerName + " for component " + component.Name);
                 }
             }
         }
@@ -199,7 +199,7 @@ namespace Structurizr.Analysis
             var type = _typeRepository.GetType(typeName);
             if (type == null)
             {
-                // todo: logging
+                Console.WriteLine("Could not find type " + typeName + " for component " + component.Name);
                 return;
             }
 
@@ -213,7 +213,7 @@ namespace Structurizr.Analysis
                 }
                 else
                 {
-                    // todo: logging
+                    Console.WriteLine("Could not find software system " + annotation.SoftwareSystemName + " for component " + component.Name);
                 }
             }
         }
@@ -223,7 +223,7 @@ namespace Structurizr.Analysis
             Type type = _typeRepository.GetType(typeName);
             if (type == null)
             {
-                // todo: logging
+                Console.WriteLine("Could not find type " + typeName + " for component " + component.Name);
                 return;
             }
 
@@ -237,7 +237,7 @@ namespace Structurizr.Analysis
                 }
                 else
                 {
-                    // todo: logging
+                    Console.WriteLine("Could not find person " + annotation.PersonName + " using component " + component.Name);
                 }
             }
         }
@@ -247,7 +247,7 @@ namespace Structurizr.Analysis
             Type type = _typeRepository.GetType(typeName);
             if (type == null)
             {
-                // todo: logging
+                Console.WriteLine("Could not find type " + typeName + " for component " + component.Name);
                 return;
             }
 
@@ -261,7 +261,7 @@ namespace Structurizr.Analysis
                 }
                 else
                 {
-                    // todo: logging
+                    Console.WriteLine("Could not find container " + annotation.ContainerName + " using component " + component.Name);
                 }
             }
         }
@@ -271,7 +271,7 @@ namespace Structurizr.Analysis
             Type type = _typeRepository.GetType(typeName);
             if (type == null)
             {
-                // todo: logging
+                Console.WriteLine("Could not find type " + typeName + " for component " + component.Name);
                 return;
             }
 
@@ -285,7 +285,7 @@ namespace Structurizr.Analysis
                 }
                 else
                 {
-                    // todo: logging
+                    Console.WriteLine("Could not find software system " + annotation.SoftwareSystemName + " using component " + component.Name);
                 }
             }
         }


### PR DESCRIPTION
Following how the Structurizr.Roslyn assembly announces warnings, I've replaced the logging to-dos with `Console.WriteLine()`. In addition, I found that interface types have true for `IsAbstract` so I reordered `FindCategory()` in the type repository classes to check `IsInterface` first. I also added a check in the `ReflectionTypeRepository.FindCategory()` to mark static classes to bring it to parity with `CecilTypeRepository.FindCategory()`.