### PR TITLE
Support widest possible range of target frameworks

### DIFF
--- a/Structurizr.Annotations/CodeElementAttribute.cs
+++ b/Structurizr.Annotations/CodeElementAttribute.cs
@@ -26,9 +26,15 @@ namespace Structurizr.Annotations
         /// <summary>
         /// Initializes a new instance of the <see cref="ComponentAttribute"/> class.
         /// </summary>
-        public CodeElementAttribute(string componentName) {
+        public CodeElementAttribute(string componentName)
+         {
+#if NET20 || PORTABLE2
+            if (String.IsNullOrEmpty(componentName) || componentName.Trim() == String.Empty)
+#else
             if (String.IsNullOrWhiteSpace(componentName))
+#endif
                 throw new ArgumentNullException(nameof(componentName));
+
             this.ComponentName = componentName;
         }
     }

--- a/Structurizr.Annotations/Structurizr.Annotations.csproj
+++ b/Structurizr.Annotations/Structurizr.Annotations.csproj
@@ -17,9 +17,30 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;net20;portable40-net40+sl4+win8+wp7;portable40-net40+sl5+win8+wp8+wpa81</TargetFrameworks>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Structurizr.Annotations.xml</DocumentationFile>
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'portable40-net40+sl4+win8+wp7'">
+    <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile2</TargetFrameworkProfile>
+    <DefineConstants>$(DefineConstants);PORTABLE2</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'portable40-net40+sl5+win8+wp8+wpa81'">
+    <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile328</TargetFrameworkProfile>
+    <DefineConstants>$(DefineConstants);PORTABLE328</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net20'">
+    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <DefineConstants>$(DefineConstants);NET20</DefineConstants>
+    <FrameworkPathOverride>$(windir)\Microsoft.NET\Framework\v2.0.50727</FrameworkPathOverride>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">

--- a/Structurizr.Annotations/UsedByContainerAttribute.cs
+++ b/Structurizr.Annotations/UsedByContainerAttribute.cs
@@ -37,7 +37,13 @@ namespace Structurizr.Annotations
         /// <param name="containerName">The name of the container which uses the attributed component.</param>
         public UsedByContainerAttribute(string containerName)
         {
-            if (String.IsNullOrWhiteSpace(containerName)) throw new ArgumentNullException(nameof(containerName));
+#if NET20 || PORTABLE2
+            if (String.IsNullOrEmpty(containerName) || containerName.Trim() == String.Empty)
+#else
+            if (String.IsNullOrWhiteSpace(containerName))
+#endif
+                throw new ArgumentNullException(nameof(containerName));
+
             this.ContainerName = containerName;
         }
     }

--- a/Structurizr.Annotations/UsedByPersonAttribute.cs
+++ b/Structurizr.Annotations/UsedByPersonAttribute.cs
@@ -37,7 +37,13 @@ namespace Structurizr.Annotations
         /// <param name="personName">The name of the person which uses the attributed component.</param>
         public UsedByPersonAttribute(string personName)
         {
-            if (String.IsNullOrWhiteSpace(personName)) throw new ArgumentNullException(nameof(personName));
+#if NET20 || PORTABLE2
+            if (String.IsNullOrEmpty(personName) || personName.Trim() == String.Empty)
+#else
+            if (String.IsNullOrWhiteSpace(personName))
+#endif
+                throw new ArgumentNullException(nameof(personName));
+
             this.PersonName = personName;
         }
     }

--- a/Structurizr.Annotations/UsedBySoftwareSystemAttribute.cs
+++ b/Structurizr.Annotations/UsedBySoftwareSystemAttribute.cs
@@ -38,8 +38,13 @@ namespace Structurizr.Annotations
         /// <param name="softwareSystemName">The name of the software system which uses the attributed component.</param>
         public UsedBySoftwareSystemAttribute(string softwareSystemName)
         {
+#if NET20 || PORTABLE2
+            if (String.IsNullOrEmpty(softwareSystemName) || softwareSystemName.Trim() == String.Empty)
+#else
             if (String.IsNullOrWhiteSpace(softwareSystemName))
+#endif
                 throw new ArgumentNullException(nameof(softwareSystemName));
+
             this.SoftwareSystemName = softwareSystemName;
         }
     }

--- a/Structurizr.Annotations/UsesComponentAttribute.cs
+++ b/Structurizr.Annotations/UsesComponentAttribute.cs
@@ -43,7 +43,13 @@ namespace Structurizr.Annotations
         /// </param>
         public UsesComponentAttribute(string description)
         {
-            if (String.IsNullOrWhiteSpace(description)) throw new ArgumentNullException(nameof(description));
+#if NET20 || PORTABLE2
+            if (String.IsNullOrEmpty(description) || description.Trim() == String.Empty)
+#else
+            if (String.IsNullOrWhiteSpace(description))
+#endif
+                throw new ArgumentNullException(nameof(description));
+
             this.Description = description;
         }
     }

--- a/Structurizr.Annotations/UsesContainerAttribute.cs
+++ b/Structurizr.Annotations/UsesContainerAttribute.cs
@@ -37,7 +37,13 @@ namespace Structurizr.Annotations
         /// <param name="containerName">The name of the container which is used by the attributed component.</param>
         public UsesContainerAttribute(string containerName)
         {
-            if (String.IsNullOrWhiteSpace(containerName)) throw new ArgumentNullException(nameof(containerName));
+#if NET20 || PORTABLE2
+            if (String.IsNullOrEmpty(containerName) || containerName.Trim() == String.Empty)
+#else
+            if (String.IsNullOrWhiteSpace(containerName))
+#endif
+                throw new ArgumentNullException(nameof(containerName));
+
             this.ContainerName = containerName;
         }
     }

--- a/Structurizr.Annotations/UsesSoftwareSystemAttribute.cs
+++ b/Structurizr.Annotations/UsesSoftwareSystemAttribute.cs
@@ -40,8 +40,13 @@ namespace Structurizr.Annotations
         /// </param>
         public UsesSoftwareSystemAttribute(string softwareSystemName)
         {
+#if NET20 || PORTABLE2
+            if (String.IsNullOrEmpty(softwareSystemName) || softwareSystemName.Trim() == String.Empty)
+#else
             if (String.IsNullOrWhiteSpace(softwareSystemName))
+#endif
                 throw new ArgumentNullException(nameof(softwareSystemName));
+
             this.SoftwareSystemName = softwareSystemName;
         }
     }


### PR DESCRIPTION
Reduce the .NET Framework target to v2.0 and add portable targets for profiles 2 & 328; between these, Structurizr.Annotations should be usable as a dependency by almost every .NET project still out there (including Mono & Xamarin ones).

[JetBrains.Annotations](https://nuget.org/packages/JetBrains.Annotations) provided the inspiration and PCL profiles to support.