### PR TITLE
ReflectionTypeRepository fix for ASP.NET Core

### DIFF
--- a/Structurizr.Reflection.Tests/AspNetCoreTests.cs
+++ b/Structurizr.Reflection.Tests/AspNetCoreTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Linq;
+using Structurizr.Analysis;
+using Structurizr.Reflection.Tests.Controllers;
+using Xunit;
+
+namespace Structurizr.Reflection.Tests
+{
+    public class AspNetCoreTests
+    {
+        [Fact]
+        public void Reflection_Success_WithAspNetCoreAssembly()
+        {
+            // arrange
+            Workspace workspace = new Workspace("Dummy ASP.NET Core WebApp", "A web application using .NET Core");
+            Model model = workspace.Model;
+            SoftwareSystem contosoUniversity = model.AddSoftwareSystem("Some Software System", "Dummy Description");
+            Container webApplication = contosoUniversity.AddContainer("Some Container", "Dummy Description", "Microsoft ASP.NET Core MVC");
+            Type controllerType = typeof(Microsoft.AspNetCore.Mvc.Controller);
+            TypeMatcherComponentFinderStrategy typeMatcherComponentFinderStrategy = new TypeMatcherComponentFinderStrategy(
+                new ExtendsClassTypeMatcher(controllerType, "ASP.NET Core MVC Controller", ".NET Core")
+            );
+
+
+            // act
+            ComponentFinder componentFinder = new ComponentFinder(
+                webApplication,
+                "Structurizr.Reflection.Tests.Controllers",
+                typeMatcherComponentFinderStrategy
+            );
+            var foundComponents = componentFinder.FindComponents(); // must successfully find controller in 'Controllers/ValuesController.cs'
+
+
+            // assert
+            Assert.Single(foundComponents);
+            Assert.Equal(nameof(StubController), foundComponents.First().Name);
+        }
+    }
+}

--- a/Structurizr.Reflection.Tests/Controllers/StubController.cs
+++ b/Structurizr.Reflection.Tests/Controllers/StubController.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Structurizr.Reflection.Tests.Controllers
+{
+    [Route("api/[controller]")]
+    public class StubController : Controller
+    {
+        [HttpGet]
+        public IEnumerable<string> Get()
+        {
+            return new string[] { "value1", "value2" };
+        }
+    }
+}

--- a/Structurizr.Reflection.Tests/Structurizr.Reflection.Tests.csproj
+++ b/Structurizr.Reflection.Tests/Structurizr.Reflection.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Structurizr.Core\Structurizr.Core.csproj" />
+    <ProjectReference Include="..\Structurizr.Reflection\Structurizr.Reflection.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Structurizr.Reflection/Analysis/ReflectionTypeRepository.cs
+++ b/Structurizr.Reflection/Analysis/ReflectionTypeRepository.cs
@@ -89,8 +89,7 @@ namespace Structurizr.Analysis
             HashSet<string> referencedTypes = new HashSet<string>();
             BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance |
                                         BindingFlags.Static | BindingFlags.FlattenHierarchy;
-            Type type = _types[typeName];
-            if (type != null)
+            if (_types.TryGetValue(typeName, out Type type))
             {
                 foreach (PropertyInfo propertyInfo in type.GetProperties(bindingFlags))
                 {

--- a/Structurizr.Reflection/Structurizr.Reflection.csproj
+++ b/Structurizr.Reflection/Structurizr.Reflection.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Structurizr.sln
+++ b/Structurizr.sln
@@ -44,6 +44,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Structurizr.Annotations", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Structurizr.Cecil.Examples", "Structurizr.Cecil.Examples\Structurizr.Cecil.Examples.csproj", "{F4C524E3-93A3-48F7-8D46-69FEB202D1E7}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Structurizr.Reflection.Tests", "Structurizr.Reflection.Tests\Structurizr.Reflection.Tests.csproj", "{5FA5244A-E920-4B5D-B7B9-2B61519DCF8D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -162,6 +164,18 @@ Global
 		{F4C524E3-93A3-48F7-8D46-69FEB202D1E7}.Release|x64.Build.0 = Release|Any CPU
 		{F4C524E3-93A3-48F7-8D46-69FEB202D1E7}.Release|x86.ActiveCfg = Release|Any CPU
 		{F4C524E3-93A3-48F7-8D46-69FEB202D1E7}.Release|x86.Build.0 = Release|Any CPU
+		{5FA5244A-E920-4B5D-B7B9-2B61519DCF8D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5FA5244A-E920-4B5D-B7B9-2B61519DCF8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5FA5244A-E920-4B5D-B7B9-2B61519DCF8D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5FA5244A-E920-4B5D-B7B9-2B61519DCF8D}.Debug|x64.Build.0 = Debug|Any CPU
+		{5FA5244A-E920-4B5D-B7B9-2B61519DCF8D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5FA5244A-E920-4B5D-B7B9-2B61519DCF8D}.Debug|x86.Build.0 = Debug|Any CPU
+		{5FA5244A-E920-4B5D-B7B9-2B61519DCF8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5FA5244A-E920-4B5D-B7B9-2B61519DCF8D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5FA5244A-E920-4B5D-B7B9-2B61519DCF8D}.Release|x64.ActiveCfg = Release|Any CPU
+		{5FA5244A-E920-4B5D-B7B9-2B61519DCF8D}.Release|x64.Build.0 = Release|Any CPU
+		{5FA5244A-E920-4B5D-B7B9-2B61519DCF8D}.Release|x86.ActiveCfg = Release|Any CPU
+		{5FA5244A-E920-4B5D-B7B9-2B61519DCF8D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR fixes a bug in `Structurizr.Analysis.ReflectionTypeRepository`, resulting in an unhandled exception whenever an ASP.NET Core assembly is examined through reflection.

Unit test added, as well, to demonstrate the scenario where the fix is needed.