### PR TITLE
Fix for Structurizr.ViewSet.Hydrate() when de-serializing from JSON

### DIFF
--- a/Structurizr.Core.Tests/IO/Json/JsonReaderTests.cs
+++ b/Structurizr.Core.Tests/IO/Json/JsonReaderTests.cs
@@ -1,0 +1,36 @@
+﻿
+using System.IO;
+using System.Linq;
+using Structurizr.IO.Json;
+using Structurizr.IO.PlantUML;
+using Xunit;
+
+namespace Structurizr.Core.Tests.IO.Json
+{
+    public class JsonReaderTests
+    {
+        [Fact]
+        public void Deserialize_ContainerView_Success()
+        {
+            // arrange
+            var workspace = new Workspace("", "");
+            var softwareSystem = workspace.Model.AddSoftwareSystem("", "");
+            workspace.Views.CreateContainerView(softwareSystem, "Container", "");
+
+            var jsonWriter = new JsonWriter(true);
+            var stringWriter = new StringWriter();
+            jsonWriter.Write(workspace, stringWriter);
+            var jsonWorkspace = stringWriter.ToString();
+
+            // act
+            var stringReader = new StringReader(jsonWorkspace);
+            var workspaceDeserialized = new JsonReader().Read(stringReader);
+
+            // assert
+            var containerView = workspaceDeserialized.Views.ContainerViews.First();
+            Assert.NotNull(containerView.Name);
+            // e.g. PlantUMLWriter.Write() will throw if ContainerView.Name is null!
+            new PlantUMLWriter().Write(workspaceDeserialized, new StringWriter());
+        }
+    }
+}

--- a/Structurizr.Core/View/ViewSet.cs
+++ b/Structurizr.Core/View/ViewSet.cs
@@ -271,6 +271,8 @@ namespace Structurizr
 
         private void HydrateView(View view)
         {
+            view.SoftwareSystem = Model.GetElement(view.SoftwareSystemId) as SoftwareSystem;
+
             foreach (ElementView elementView in view.Elements)
             {
                 elementView.Element = Model.GetElement(elementView.Id);


### PR DESCRIPTION
This PR fixes the following scenario:
1. Create a workspace **with a ContainerView** in it
1. Export the workspace to JSON
1. Import back that JSON to create an identical workspace
1. Write out this new workspace as a PlantUML diagram.

Since the `ContainerView.Name` is `null`, PlantUMLWriter will throw.