### PR TITLE
Use Mono.Cecil 0.10.0 final

### DIFF
--- a/Structurizr.Cecil.Examples/Structurizr.Cecil.Examples.csproj
+++ b/Structurizr.Cecil.Examples/Structurizr.Cecil.Examples.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.10.0-beta6" />
+    <PackageReference Include="Mono.Cecil" Version="0.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Structurizr.Cecil/Structurizr.Cecil.csproj
+++ b/Structurizr.Cecil/Structurizr.Cecil.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.10.0-beta6" />
+    <PackageReference Include="Mono.Cecil" Version="0.10.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since the final release of Mono.Cecil 0.10.0 is now available, we should switch to using that instead of a beta pre-release.