### PR TITLE
Check relationships by source and destination ID

### DIFF
--- a/Structurizr.Core.Tests/Model/ModelTests.cs
+++ b/Structurizr.Core.Tests/Model/ModelTests.cs
@@ -133,15 +133,19 @@ namespace Structurizr.Core.Tests
         }
 
         [Fact]
-        public void Test_AddRelationship_DisallowsTheSameRelationshipToBeAddedWithDifferentDescriptions()
+        public void Test_AddRelationship_DisallowsMultipleRelationshipsBetweenComponents()
         {
-            SoftwareSystem element1 = Model.AddSoftwareSystem("Element 1", "Description");
-            SoftwareSystem element2 = Model.AddSoftwareSystem("Element 2", "Description");
-            Relationship relationship1 = element1.Uses(element2, "Does something", "");
-            Relationship relationship2 = element1.Uses(element2, "Does something else", "");
-            Assert.True(element1.Has(relationship1));
+            SoftwareSystem system1 = Model.AddSoftwareSystem("System 1", "Description");
+            Container container1 = system1.AddContainer("Container 1", "Description", "");
+
+            Component component1 = container1.AddComponent("Component 1", "Description");
+            Component component2 = container1.AddComponent("Component 2", "Description");
+
+            Relationship relationship1 = component1.Uses(component2, "Does something", "");
+            Relationship relationship2 = component1.Uses(component2, "Does something else", "");
+            Assert.True(component1.Has(relationship1));
             Assert.Null(relationship2);
-            Assert.Equal(1, element1.Relationships.Count);
+            Assert.Equal(1, component1.Relationships.Count);
             Assert.Equal("Does something", relationship1.Description);
         }
 

--- a/Structurizr.Core.Tests/Model/ModelTests.cs
+++ b/Structurizr.Core.Tests/Model/ModelTests.cs
@@ -132,7 +132,18 @@ namespace Structurizr.Core.Tests
             Assert.Equal(1, element1.Relationships.Count);
         }
 
-
+        [Fact]
+        public void Test_AddRelationship_DisallowsTheSameRelationshipToBeAddedWithDifferentDescriptions()
+        {
+            SoftwareSystem element1 = Model.AddSoftwareSystem("Element 1", "Description");
+            SoftwareSystem element2 = Model.AddSoftwareSystem("Element 2", "Description");
+            Relationship relationship1 = element1.Uses(element2, "Does something", "");
+            Relationship relationship2 = element1.Uses(element2, "Does something else", "");
+            Assert.True(element1.Has(relationship1));
+            Assert.Null(relationship2);
+            Assert.Equal(1, element1.Relationships.Count);
+            Assert.Equal("Does something", relationship1.Description);
+        }
 
     }
 }

--- a/Structurizr.Core/Model/Element.cs
+++ b/Structurizr.Core/Model/Element.cs
@@ -98,7 +98,7 @@ namespace Structurizr
 
         public bool Has(Relationship relationship)
         {
-            return Relationships.Contains(relationship);
+            return Relationships.Any(r => r.SourceId == relationship.SourceId && r.DestinationId == relationship.DestinationId);
         }
 
         /// <summary>
@@ -192,5 +192,9 @@ namespace Structurizr
             return CanonicalName.Equals(element.CanonicalName);
         }
 
+        public override int GetHashCode()
+        {
+            return CanonicalName.GetHashCode() ^ typeof(Element).GetHashCode();
+        }
     }
 }

--- a/Structurizr.Core/Model/Element.cs
+++ b/Structurizr.Core/Model/Element.cs
@@ -98,7 +98,12 @@ namespace Structurizr
 
         public bool Has(Relationship relationship)
         {
-            return Relationships.Any(r => r.SourceId == relationship.SourceId && r.DestinationId == relationship.DestinationId);
+            if (relationship.Source is Component && relationship.Destination is Component)
+            {
+                return Relationships.Any(r => r.SourceId == relationship.SourceId && r.DestinationId == relationship.DestinationId);
+            }
+
+            return Relationships.Contains(relationship);
         }
 
         /// <summary>


### PR DESCRIPTION
Also adds another test case to ensure A->B relationships with different descriptions or technologies don't slip through.