### PR TITLE
Fix/technologies

### DIFF
--- a/Structurizr.PlantUML/IO/PlantUML/PlantUMLWriter.cs
+++ b/Structurizr.PlantUML/IO/PlantUML/PlantUMLWriter.cs
@@ -341,8 +341,8 @@ namespace Structurizr.IO.PlantUML
                 if (HasValue(relationship.Description) || HasValue(relationship.Technology))
                 {
                     writer.Write(
-                        String.Format(": {0}{1}",
-                            HasValue(relationship.Description) ? ": " + relationship.Description : "",
+                        String.Format(" :{0}{1}",
+                            HasValue(relationship.Description) ? " " + relationship.Description : "",
                             HasValue(relationship.Technology) ? " <<" + relationship.Technology + ">>" : "")
                     );
                 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,5 +18,6 @@ build_script:
     }
 test_script:
 - ps: dotnet test .\Structurizr.Core.Tests\Structurizr.Core.Tests.csproj
+- ps: dotnet test .\Structurizr.PlantUML.Tests\Structurizr.PlantUML.Tests.csproj
 artifacts:
 - path: '*\bin\Release\*.nupkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,5 @@ build_script:
     }
 test_script:
 - ps: dotnet test .\Structurizr.Core.Tests\Structurizr.Core.Tests.csproj
-- ps: dotnet test .\Structurizr.PlantUML.Tests\Structurizr.PlantUML.Tests.csproj
 artifacts:
 - path: '*\bin\Release\*.nupkg'


### PR DESCRIPTION
I am really sorry - I broke the tests with #44! 💥🙈

That was careless of me. I don't have dotnet 1.x installed so I used appveyor to run the tests for me. I didn't realise that the PlantUML.Test project aren't run on the CI check.

master currently fails, with an extra colon inserted if both a description and technology are provided. Alignment isn't correct either.

This fix applies spaces/colons as expected and the tests now pass.

The tests should actually pass now 😳