### PR TITLE
Fix for CanonicalNames in [UsesContainer] and [UsedByContainer] annotations

### DIFF
--- a/Structurizr.Cecil/Analysis/StructurizrAnnotationsComponentFinderStrategy.cs
+++ b/Structurizr.Cecil/Analysis/StructurizrAnnotationsComponentFinderStrategy.cs
@@ -233,7 +233,7 @@ namespace Structurizr.Analysis
             var annotations = type.ResolvableAttributes<UsesContainerAttribute>().ToList();
             foreach(UsesContainerAttribute annotation in annotations)
             {
-                Container container = FindContainerByNameOrId(component, annotation.ContainerName);
+                Container container = FindContainerByNameOrCanonicalNameOrId(component, annotation.ContainerName);
                 if (container != null)
                 {
                     string description = annotation.Description;
@@ -289,7 +289,7 @@ namespace Structurizr.Analysis
             var annotations = type.ResolvableAttributes<UsedByContainerAttribute>().ToList();
             foreach(UsedByContainerAttribute annotation in annotations)
             {
-                Container container = FindContainerByNameOrId(component, annotation.ContainerName);
+                Container container = FindContainerByNameOrCanonicalNameOrId(component, annotation.ContainerName);
                 if (container != null)
                 {
                     string description = annotation.Description;
@@ -357,14 +357,23 @@ namespace Structurizr.Analysis
             }
         }
 
-        private Container FindContainerByNameOrId(Component component, string name)
+        private Container FindContainerByNameOrCanonicalNameOrId(Component component, string name)
         {
             // assume that the container resides in the same software system
             Container container = component.Container.SoftwareSystem.GetContainerWithName(name);
             if (container == null)
             {
-                // perhaps it's an element ID?
-                container = component.Model.GetElement(name) as Container;
+                // perhaps a canonical name has been specified
+                Element element = component.Model.GetElementWithCanonicalName(name);
+                if (element != null && element is Container)
+                {
+                    container = (Container) element;
+                }
+                else
+                {
+                    // perhaps it's an element ID?
+                    container = component.Model.GetElement(name) as Container;
+                }
             }
 
             return container;

--- a/Structurizr.Core.Tests/Model/ModelTests.cs
+++ b/Structurizr.Core.Tests/Model/ModelTests.cs
@@ -199,7 +199,50 @@ namespace Structurizr.Core.Tests
             }
         }
 
+        [Fact]
+        public void Test_GetElementWithCanonicalName_ThrowsAnException_WhenANullCanonicalNameIsSpecified()
+        {
+            try
+            {
+                Model.GetElementWithCanonicalName(null);
+            }
+            catch (ArgumentException ae)
+            {
+                Assert.Equal("A canonical name must be specified.", ae.Message);
+            }
+        }
 
+        [Fact]
+        public void Test_ElementWithCanonicalName_ThrowsAnException_WhenAnEmptyCanonicalNameIsSpecified()
+        {
+            try
+            {
+                Model.GetElementWithCanonicalName(" ");
+            }
+            catch (ArgumentException ae)
+            {
+                Assert.Equal("A canonical name must be specified.", ae.Message);
+            }
+        }
+
+        [Fact]
+        public void Test_GetElementWithCanonicalName_ReturnsNull_WhenAnElementWithTheSpecifiedCanonicalNameDoesNotExist()
+        {
+            Assert.Null(Model.GetElementWithCanonicalName("Software System"));
+        }
+
+        [Fact]
+        public void Test_ElementWithCanonicalName_ReturnsTheElement_WhenAnElementWithTheSpecifiedCanonicalNameExists()
+        {
+            SoftwareSystem softwareSystem = Model.AddSoftwareSystem("Software System", "Description");
+
+            Assert.Same(Model.GetElementWithCanonicalName("/Software System"), softwareSystem);
+            Assert.Same(Model.GetElementWithCanonicalName("Software System"), softwareSystem);
+
+            Container container = softwareSystem.AddContainer("Web Application", "Description", "Technology");
+            Assert.Same(container, Model.GetElementWithCanonicalName("/Software System/Web Application"));
+            Assert.Same(container, Model.GetElementWithCanonicalName("Software System/Web Application"));
+        }
 
     }
 }

--- a/Structurizr.Core.Tests/Structurizr.Core.Tests.csproj
+++ b/Structurizr.Core.Tests/Structurizr.Core.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/Structurizr.Core/Model/Model.cs
+++ b/Structurizr.Core/Model/Model.cs
@@ -499,6 +499,27 @@ namespace Structurizr
             return _elementsById[id];
         }
 
+        /// <summary>
+        /// Gets the element with the specified canonical name.
+        /// </summary>
+        /// <param name="canonicalName">the canonical name (e.g. /SoftwareSystem/Container)</param>
+        /// <returns>the Element with the given canonical name, or null if one doesn't exist</returns>
+        public Element GetElementWithCanonicalName(string canonicalName)
+        {
+            if (string.IsNullOrWhiteSpace(canonicalName))
+            {
+                throw new ArgumentException("A canonical name must be specified.");
+            }
+
+            // canonical names start with a leading slash, so add this if it's missing
+            if (!canonicalName.StartsWith("/"))
+            {
+                canonicalName = "/" + canonicalName;
+            }
+
+            return _elementsById.Values.FirstOrDefault(x => x.CanonicalName == canonicalName);
+        }
+
         public IEnumerable<Element> GetElements()
         {
             return _elementsById.Values;

--- a/Structurizr.Reflection/Analysis/StructurizrAnnotationsComponentFinderStrategy.cs
+++ b/Structurizr.Reflection/Analysis/StructurizrAnnotationsComponentFinderStrategy.cs
@@ -201,7 +201,7 @@ namespace Structurizr.Analysis
             var annotations = type.GetCustomAttributes<UsesContainerAttribute>();
             foreach(UsesContainerAttribute annotation in annotations)
             {
-                Container container = FindContainerByNameOrId(component, annotation.ContainerName);
+                Container container = FindContainerByNameOrCanonicalNameOrId(component, annotation.ContainerName);
                 if (container != null)
                 {
                     component.Uses(container, annotation.Description, annotation.Technology);
@@ -273,7 +273,7 @@ namespace Structurizr.Analysis
             var annotations = type.GetCustomAttributes<UsedByContainerAttribute>();
             foreach (UsedByContainerAttribute annotation in annotations)
             {
-                Container container = FindContainerByNameOrId(component, annotation.ContainerName);
+                Container container = FindContainerByNameOrCanonicalNameOrId(component, annotation.ContainerName);
                 if (container != null)
                 {
                     container.Uses(component, annotation.Description, annotation.Technology);
@@ -309,14 +309,23 @@ namespace Structurizr.Analysis
             }
         }
 
-        private Container FindContainerByNameOrId(Component component, string name)
+        private Container FindContainerByNameOrCanonicalNameOrId(Component component, string name)
         {
             // assume that the container resides in the same software system
             Container container = component.Container.SoftwareSystem.GetContainerWithName(name);
             if (container == null)
             {
-                // perhaps it's an element ID?
-                container = component.Model.GetElement(name) as Container;
+                // perhaps a canonical name has been specified
+                Element element = component.Model.GetElementWithCanonicalName(name);
+                if (element != null && element is Container)
+                {
+                    container = (Container)element;
+                }
+                else
+                {
+                    // perhaps it's an element ID?
+                    container = component.Model.GetElement(name) as Container;
+                }
             }
 
             return container;


### PR DESCRIPTION
Model.GetElementWithCanonicalName port from Java, used from annotation analysis to find external containers.