### PR TITLE
Fixes: #75 - HttpClient shouldn't be disposed all the time

### DIFF
--- a/Structurizr.Client.Tests/Api/StructurizrClientTests.cs
+++ b/Structurizr.Client.Tests/Api/StructurizrClientTests.cs
@@ -29,15 +29,6 @@ namespace Structurizr.Api.Tests
         }
 
         [Fact]
-        public void Test_Construction_WithFourParameters()
-        {
-            _structurizrClient = new StructurizrClient("https://localhost", "key", "secret", null);
-            Assert.Equal("https://localhost", _structurizrClient.Url);
-            Assert.Equal("key", _structurizrClient.ApiKey);
-            Assert.Equal("secret", _structurizrClient.ApiSecret);
-        }
-
-        [Fact]
         public void Test_Construction_WithThreeParameters_TruncatesTheApiUrl_WhenTheApiUrlHasATrailingSlashCharacter()
         {
             _structurizrClient = new StructurizrClient("https://localhost/", "key", "secret");
@@ -183,15 +174,6 @@ namespace Structurizr.Api.Tests
             var httpClient2 = testClient.GetClient();
 
             Assert.Equal(httpClient1.GetHashCode(), httpClient2.GetHashCode());
-        }
-
-        [Fact]
-        public void Test_not_overriden_createHttpClient_returns_injected_httpClient()
-        {
-            var httpClient = new HttpClient();
-            var testClient = new TestStructurizrClient("https://localhost", "key", "secret", httpClient);
-
-            Assert.Equal(httpClient.GetHashCode(), testClient.GetClient().GetHashCode());
         }
 
         [Fact]

--- a/Structurizr.Client.Tests/Api/TestStructurizrClient.cs
+++ b/Structurizr.Client.Tests/Api/TestStructurizrClient.cs
@@ -1,0 +1,25 @@
+﻿using Structurizr.Api;
+using System.Net.Http;
+
+namespace Structurizr.Client.Tests.Api
+{
+    internal class TestStructurizrClient : StructurizrClient
+    {
+        public TestStructurizrClient(string apiKey, string apiSecret)
+            : base(apiKey, apiSecret)
+        {
+        }
+
+        public TestStructurizrClient(string apiUrl, string apiKey, string apiSecret)
+            : base(apiUrl, apiKey, apiSecret)
+        {
+        }
+
+        public TestStructurizrClient(string apiUrl, string apiKey, string apiSecret, HttpClient httpClient)
+            : base(apiUrl, apiKey, apiSecret, httpClient)
+        {
+        }
+
+        public HttpClient GetClient() => base.createHttpClient();
+    }
+}

--- a/Structurizr.Client.Tests/Api/TestStructurizrClient.cs
+++ b/Structurizr.Client.Tests/Api/TestStructurizrClient.cs
@@ -15,11 +15,6 @@ namespace Structurizr.Client.Tests.Api
         {
         }
 
-        public TestStructurizrClient(string apiUrl, string apiKey, string apiSecret, HttpClient httpClient)
-            : base(apiUrl, apiKey, apiSecret, httpClient)
-        {
-        }
-
         public HttpClient GetClient() => base.createHttpClient();
     }
 }

--- a/Structurizr.Client/Api/StructurizrClient.cs
+++ b/Structurizr.Client/Api/StructurizrClient.cs
@@ -101,22 +101,10 @@ namespace Structurizr.Api
         /// <param name="apiKey">The API key of your workspace.</param>
         /// <param name="apiSecret">The API secret of your workspace.</param>
         public StructurizrClient(string apiUrl, string apiKey, string apiSecret)
-            : this(apiUrl, apiKey, apiSecret, null)
-        {
-        }
-
-        /// <summary>
-        /// Creates a new Structurizr client with the specified API URL, key and secret.
-        /// </summary>
-        /// <param name="apiUrl">The URL of your Structurizr instance.</param>
-        /// <param name="apiKey">The API key of your workspace.</param>
-        /// <param name="apiSecret">The API secret of your workspace.</param>
-        public StructurizrClient(string apiUrl, string apiKey, string apiSecret, HttpClient httpClient)
         {
             Url = apiUrl;
             ApiKey = apiKey;
             ApiSecret = apiSecret;
-            _httpClient = httpClient;
 
             WorkspaceArchiveLocation = new DirectoryInfo(".");
             MergeFromRemote = true;


### PR DESCRIPTION
Changes:
- Added constructor overload that accepts HttpClient instance
- Put a lock around createHttpClient method so it always returns the same HttpClient instance
- Added some tests to cover new constructor and concurrency scenario