### PR TITLE
Structurizr.Examples: fix build (missing using)

### DIFF
--- a/Structurizr.Examples/BigBankPlc.cs
+++ b/Structurizr.Examples/BigBankPlc.cs
@@ -1,5 +1,5 @@
-﻿using System.IO;
-using System.Linq;
+﻿using System.Linq;
+using Structurizr.Api;
 using Structurizr.Core.Util;
 using Structurizr.Documentation;
 


### PR DESCRIPTION
Couldn't compile it with VS 2019

(maybe you want to update the project versions to <Version>1.0.0</Version> but I was not sure)